### PR TITLE
New /competitions/current URL

### DIFF
--- a/src/app/current-competition-guard.ts
+++ b/src/app/current-competition-guard.ts
@@ -1,0 +1,32 @@
+import { ActivatedRouteSnapshot, CanActivateFn, Router, RouterStateSnapshot, UrlTree } from "@angular/router";
+import { Observable, take } from "rxjs";
+import { inject } from "@angular/core";
+import { Store } from "@ngrx/store";
+import { Competitions } from "store/reducers";
+import { Competition } from "models/competition.model";
+
+// Redirects to the current competition or the /competitions
+// page if there is no current competition
+export const CurrentCompetitionGuard : CanActivateFn = (
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ) : Observable<boolean | UrlTree>
+  | Promise<boolean | UrlTree>
+  | boolean
+  | UrlTree => {
+  
+    const store:Store = inject(Store);
+    const competition: Observable<Competition | null> = store.select(Competitions.selectCurrentCompetition);
+    const url:String[] = ['/competitions'];
+    const subscription = competition.pipe(take(1)).subscribe(competition => {
+      if (!!competition) {
+        url.push(competition.id);
+      }
+    });
+    subscription.unsubscribe();
+
+    const router:Router = inject(Router);
+    router.navigate(url);
+    
+    return true;
+  };

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -8,6 +8,7 @@ import { RulesComponent } from "./components/pages/rules/rules.component";
 import { PlayerPageComponent } from "./components/player/player-page/player-page.component";
 import { PlayersComponent } from "./components/player/players/players.component";
 import { YearPageComponent } from "./components/years/year-page/year-page.component";
+import { CurrentCompetitionGuard } from "./current-competition-guard";
 
 export const routes: Routes = [
   {
@@ -21,6 +22,11 @@ export const routes: Routes = [
   },
   {
     path: 'competitions',
+    component: CompetitionsComponent
+  },
+  {
+    path: 'competitions/current',
+    canActivate: [CurrentCompetitionGuard],
     component: CompetitionsComponent
   },
   {
@@ -48,3 +54,4 @@ export const routes: Routes = [
     component: YearPageComponent
   }
 ];
+


### PR DESCRIPTION
This PR adds a new /competitions/current URL that redirects to the current competition or the /competitions page if there is none.