### PR TITLE
Add bulk import to pokemon list generator

### DIFF
--- a/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.html
+++ b/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.html
@@ -16,36 +16,117 @@
 }]
     </pre>
   </div>
-
-  <div class="card">
-    <div class="card-body">
-      <h3>Pokémon</h3>
+  <div>
+    <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
+      <li [ngbNavItem]="'single'">
+        <a ngbNavLink>Single Import</a>
+        <ng-template ngbNavContent>
+          <div class="card">
+            <div class="card-body">
+              <h3>Pokémon</h3>
+            </div>
+        
+            <div class="mx-3 mb-3">
+              <input
+                    autocomplete="off"
+                    type="text"
+                    class="form-control"
+                    placeholder="Search"
+                    (keyup)="filterPokemon($event)" />
+            </div>
+        
+              <ul class="list-group list-group-flush">
+              @for (pokemon of unselectedPokemon(); track pokemon.id) {
+                <li class="list-group-item d-flex align-items-center">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-success me-3"
+                    (click)="addPokemon(pokemon)">
+                    +
+                  </button>
+                  <sp-pokemon
+                    [pokemon]="pokemon"
+                    class="flex-grow-1">
+                  </sp-pokemon>
+                </li>
+              }
+            </ul>
+          </div>
+        
+        </ng-template>
+      </li>
+    
+      <li [ngbNavItem]="'bulk'">
+        <a ngbNavLink>Bulk Import</a>
+        <ng-template ngbNavContent>
+          <div class="card">
+            <div class="card-body">
+              <h3>Bulk Import</h3>
+            </div>
+        
+            <div class="mx-3 mb-3">
+              <textarea #pokemonTextArea class="form-control" placeholder="Paste Pokemon Here"></textarea>
+            </div>
+        
+            <div class="mx-3 mb-3">
+              <button
+                (click)="onParse()"
+                class="btn btn-outline-success me-3">
+                Parse
+              </button>
+        
+              <button
+                (click)="addAll()"
+                class="btn btn-outline-success">
+                Add All
+              </button>
+            </div>
+        
+        
+            <div class="mx-3 mb-3" #result>
+              <h4>Result</h4>
+        
+              <ul class="list-group list-group-flush">
+                @for (parsedPokemon of parsedPokemon(); track parsedPokemon.text) {
+                  <li class="list-group-item d-flex flex-row">
+                    <span class="pe-5">
+                      <input 
+                        type="text" 
+                        [value]=parsedPokemon.text 
+                        style="width: 10em"
+                        (input)="onKeyPress($event, parsedPokemon)"
+                        />
+                    </span>
+                    <span class="flex-grow-1">
+                      @if (parsedPokemon.pokemon) {
+                        <div class="d-flex">
+                          <button
+                            type="button"
+                            class="btn btn-sm btn-outline-success me-3"
+                            (click)="addPokemon(parsedPokemon.pokemon)">
+                            +
+                          </button>
+                          <sp-pokemon
+                            [pokemon]="parsedPokemon.pokemon"
+                            class="flex-grow-1">
+                          </sp-pokemon>
+                        </div>
+                      }
+                    </span>            
+                </li>
+                }
+              </ul>
+          
+            </div>     
+          </div>
+        </ng-template>
+      </li>
+    
+    </ul>  
+    <div
+      [ngbNavOutlet]="nav"
+      class="">
     </div>
-
-    <div class="mx-3 mb-3">
-      <input
-            autocomplete="off"
-            type="text"
-            class="form-control"
-            placeholder="Search"
-            (keyup)="filterPokemon($event)" />
-    </div>
-
-      <ul class="list-group list-group-flush">
-      @for (pokemon of unselectedPokemon(); track pokemon.id) {
-        <li class="list-group-item d-flex align-items-center">
-          <button
-            type="button"
-            class="btn btn-sm btn-outline-success me-3"
-            (click)="addPokemon(pokemon)">
-            +
-          </button>
-          <sp-pokemon
-            [pokemon]="pokemon"
-            class="flex-grow-1">
-          </sp-pokemon>
-        </li>
-      }
-    </ul>
   </div>
+
 </div>

--- a/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.ts
+++ b/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.ts
@@ -1,33 +1,36 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Signal,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Signal, ViewChild, inject, signal } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Pokemon } from 'models/pokemon.model';
 import { PokemonActions } from 'store/actions';
 import { Pokemons } from 'store/reducers';
 import { CopyToClipboardComponent } from '../../_shared/copy-to-clipboard/copy-to-clipboard.component';
 import { PokemonComponent } from '../../pokemon/pokemon/pokemon.component';
+import { NgbNav, NgbNavContent, NgbNavItem, NgbNavItemRole, NgbNavLink, NgbNavLinkBase, NgbNavOutlet } from '@ng-bootstrap/ng-bootstrap';
+
+type ParsedPokemon = {
+  text: string;
+  pokemon: Pokemon | undefined;
+}
 
 @Component({
-  selector: 'sp-pokemon-list-generator',
-  templateUrl: './pokemon-list-generator.component.html',
-  styleUrls: ['./pokemon-list-generator.component.sass'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
-  imports: [PokemonComponent, CopyToClipboardComponent],
+    selector: 'sp-pokemon-list-generator',
+    templateUrl: './pokemon-list-generator.component.html',
+    styleUrls: ['./pokemon-list-generator.component.sass'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    imports: [PokemonComponent, CopyToClipboardComponent, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLink, NgbNavLinkBase, NgbNavContent, NgbNavOutlet]
 })
 export class PokemonListGeneratorComponent {
   private readonly store: Store = inject(Store);
 
-  selectedPokemon: Signal<Pokemon[]> = this.store.selectSignal(
-    Pokemons.selectSelectedPokemon
-  );
-  unselectedPokemon: Signal<Pokemon[]> = this.store.selectSignal(
-    Pokemons.selectUnselectedPokemon
-  );
+  @ViewChild('pokemonTextArea') pokemonTextArea!: ElementRef;
+
+  selectedPokemon:Signal<Pokemon[]> = this.store.selectSignal(Pokemons.selectSelectedPokemon);
+  unselectedPokemon:Signal<Pokemon[]> = this.store.selectSignal(Pokemons.selectUnselectedPokemon);
+  parsedPokemon:Signal<ParsedPokemon[]> = signal([]);
+  allPokemon: Signal<Pokemon[]> = this.store.selectSignal(Pokemons.selectAll);
+
+  active = 'single';
 
   addPokemon(pokemon: Pokemon) {
     this.store.dispatch(PokemonActions.select({ pokemon }));
@@ -40,4 +43,52 @@ export class PokemonListGeneratorComponent {
   filterPokemon(event: any): void {
     this.store.dispatch(PokemonActions.filter({ query: event.target.value }));
   }
+
+
+  parse(parsedPokemon : ParsedPokemon) : void {
+    const normalizedText = parsedPokemon.text.replace(/[^a-zA-Z\s♀♂().-\\']/g,'').trim().toLowerCase();
+    if (!normalizedText) {
+      return;
+    }
+
+    // First try an exact match
+    parsedPokemon.pokemon = this.allPokemon().find(p => p.name.toLowerCase() == normalizedText);
+
+    // Next try what's close
+    if (!parsedPokemon.pokemon) {
+      parsedPokemon.pokemon = this.allPokemon().find(p => p.name.toLowerCase().includes(normalizedText));    
+    }
+  }
+
+
+  onParse() : void {
+    this.parsedPokemon = signal([]);
+
+    const textArea = this.pokemonTextArea.nativeElement.value;
+    for (const row of textArea.split('\n')) {
+      const parsedPokemon = {
+        text : row,
+        pokemon: undefined
+      }
+
+      this.parse(parsedPokemon);
+      this.parsedPokemon().push(parsedPokemon);
+    }
+  }
+
+  onKeyPress(event: Event, parsedPokemon : ParsedPokemon) : void {
+    parsedPokemon.text = (event.target as HTMLInputElement).value;    
+    this.parse(parsedPokemon);
+  }
+
+  addAll() {
+    for (const parsedPokemon of this.parsedPokemon()) {
+      const pokemon = parsedPokemon.pokemon;
+      if (!!pokemon) {
+        this.addPokemon(pokemon);
+      }
+    }
+
+  }
+
 }


### PR DESCRIPTION
This pull request adds tabs to the Pokemon List generator for "Single Import" and "Bulk Import".  "Single Import" behaves as it did previously.  "Bulk Import" has a textarea for a list of pokemon.  It assumes one pokemon per line.  It has a "parse" button which goes through each line and tries to identify which pokemon it is.  It then produces a result with each line and the pokemon it thinks was intended.  The admin can then bulk add all of the pokemon, fix names that are wrong or add them individually.  The goal is to speed up the import process for the admin.