### PR TITLE
Fix point and competition data for 2017-2022

### DIFF
--- a/src/data/competitions/2017.data.ts
+++ b/src/data/competitions/2017.data.ts
@@ -224,14 +224,7 @@ export const competitionsData2017: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2017', type: 'year' } }
     }
   }

--- a/src/data/competitions/2018.data.ts
+++ b/src/data/competitions/2018.data.ts
@@ -528,7 +528,7 @@ export const competitionsData2018: { [id: string]: ICompetitionEntity } = {
     id: 'f2ac64fe-a439-46fe-97af-bd10b1e09fd3',
     attributes: {
       description: 'n/a',
-      endDate: '2018-11-27',
+      endDate: '2018-10-27',
       startDate: '2018-10-13',
       theme: 'Spooky'
     },
@@ -554,8 +554,8 @@ export const competitionsData2018: { [id: string]: ICompetitionEntity } = {
     id: '6bedf793-7fd6-4d55-8fe6-b9b080dc60a2',
     attributes: {
       description: 'n/a',
-      endDate: '2018-12-14',
-      startDate: '2018-11-28',
+      endDate: '2018-11-10',
+      startDate: '2018-10-28',
       theme: 'Human-like'
     },
     relationships: {
@@ -640,14 +640,7 @@ export const competitionsData2018: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2018', type: 'year' } }
     }
   }

--- a/src/data/competitions/2019.data.ts
+++ b/src/data/competitions/2019.data.ts
@@ -17,13 +17,815 @@ export const competitionsData2019: { [id: string]: ICompetitionEntity } = {
         data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoqueen remove
+            id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cloyster remove
+            id: 'be37c657-0018-4afc-9bab-dde828130189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lanturn remove
+            id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phanpy remove
+            id: '5a1de7c3-bcb3-4eb9-8365-e45e404bb023',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poochyena remove
+            id: 'ed1552a1-de0a-4799-87e1-ee0c43ce765d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delcatty remove
+            id: 'b2e08f69-71b5-4f7e-92a0-c2e38d54d300',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corphish remove
+            id: '5fd6660f-f631-41eb-a4c9-a437e062417c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Castform remove
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bagon remove
+            id: '6aa962cb-3176-426d-9a74-f257c805b641',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bastiodon remove
+            id: '754ae45a-c41b-4004-9cc9-f93638145b79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glameow remove
+            id: 'b0fff790-de0b-41fe-b0cd-05117c22b6f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chatot remove
+            id: '1a0b6846-d45a-4fd2-98a7-7a3946743e7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oshawott remove
+            id: '1bf76a95-4044-4689-bc8b-d587c347126a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansage remove
+            id: 'ab32e387-5435-4bc4-86d5-462a8867f1bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unfezant remove
+            id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swadloon remove
+            id: '1f85c9c1-6ec1-4062-b8d5-df96564712a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klinklang remove
+            id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quilladin remove
+            id: '3e8065f7-1785-4754-b728-f0ec7e6bb094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Florges remove
+            id: '60cbac1b-57e8-40af-8489-34c92c1c358b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gourgeist remove
+            id: '8efb8e70-779f-43f6-b884-e11073accd58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcanion remove
+            id: 'e6295a1b-75b7-42a1-b0b1-a70cb13cf3e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikipek remove
+            id: '30416667-3675-473f-9a38-0eec7c4960ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewpider remove
+            id: '8186274b-5267-4752-824a-5fe3233bafbc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magearna remove
+            id: '862b37f7-db2d-400a-ba7d-1a6ed16e29d2',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2019', type: 'year' } }
     }
   }
@@ -562,14 +1364,7 @@ export const competitionsData2019: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2019', type: 'year' } }
     }
   }

--- a/src/data/competitions/2020.data.ts
+++ b/src/data/competitions/2020.data.ts
@@ -19,11 +19,1558 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Slowpoke (Galarian) remove
+            id: '11bb00ef-40ed-47ae-9b04-e543c60e48fc',
+            type: 'pokemon'
+          }
+        },  
+
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+            
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuckle remove
+            id: 'a9056e67-acfe-4264-9f78-06098b5e10dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Smeargle remove
+            id: 'd19a4e77-6a74-496b-b7f7-9ad96e80d6e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minun remove
+            id: 'a07fae2b-ead4-4ea8-a93a-d3cd43a822b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volbeat remove
+            id: 'c0e1b0e4-2b2a-43b8-8d4c-c21c31635bbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Illumise remove
+            id: '0b30f410-05e9-43c2-a11a-ffa941c2eb7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zangoose remove
+            id: '62d87f95-80cd-4313-9791-a7fd201c97d4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunatone remove
+            id: 'bf708485-a15c-4b56-9c9a-e93731114db0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solrock remove
+            id: 'd71dc002-63ff-4fb6-ad1d-527f48c929d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Castform remove
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regirock remove
+            id: '8fb21e0a-dda9-4abe-9ce8-ee01ce0ff7c5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regice remove
+            id: 'bc9d6986-f768-4988-a37c-f7437709c9d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Registeel remove
+            id: 'dd83ad95-5524-4d5c-9a9b-dce9210777b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latias remove
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jirachi remove
+            id: 'd81fc796-f8c1-4919-a286-d0d7ceafa0f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deoxys remove
+            id: '3f3c455d-707a-4212-a5d1-c0e743bbd970',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chatot remove
+            id: '1a0b6846-d45a-4fd2-98a7-7a3946743e7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phione remove
+            id: '3c1ff9c9-4164-48b4-9f45-f87abdf0f3aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arceus remove
+            id: 'b35607d9-2dce-4ee6-a203-b5c57641297c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Throh remove
+            id: '474d999f-e6d0-493c-8973-66e1c838c291',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sawk remove
+            id: '22c654ac-baba-42a6-bc06-49eb9c04029b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Maractus remove
+            id: '7af0e968-d555-4acb-b030-8fdd64600615',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cryogonal remove
+            id: 'e798e439-2d71-4e85-8c9b-1c1e99fe331d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk (Galarian) remove
+            id: '3c64e523-a068-49e0-9b62-4cb9c4400965',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cobalion remove
+            id: 'a4a4529d-cb64-4e76-876f-5c910ba16989',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meloetta remove
+            id: 'ad7f8437-dc5d-4ecd-af94-e54190abdba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Genesect remove
+            id: '5a304b6a-7ceb-4063-bd14-5a7d4cae5812',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furfrou remove
+            id: '97ac9b43-d8ce-4dfe-a7de-928e87bd9f0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carbink remove
+            id: 'e11410e2-245b-431c-8ff1-5a6088cf1699',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diancie remove
+            id: 'd45feb65-7e80-4bc0-92e2-fa817f364fcf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoopa remove
+            id: '06d0f6c9-6cb0-4b49-b922-d8048d582a2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcanion remove
+            id: 'e6295a1b-75b7-42a1-b0b1-a70cb13cf3e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wishiwashi remove
+            id: 'e23fab77-2715-434d-b146-4d9664479ffb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oranguru remove
+            id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Komala remove
+            id: '360c0865-0bfc-46dd-807d-2532ddfab4dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Turtonator remove
+            id: '3193a867-b51e-407d-9476-5dd9fbe17a6c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togedemaru remove
+            id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bruxish remove
+            id: 'd06db98e-bac0-4676-bf64-0cb0101ef847',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Lele remove
+            id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buzzwole remove
+            id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xurkitree remove
+            id: 'b456167a-44ea-4a3f-aacf-e7aa5f4bca5d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magearna remove
+            id: '862b37f7-db2d-400a-ba7d-1a6ed16e29d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshadow remove
+            id: '6d76251d-04a5-40bc-9f62-5e95790703e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blacephalon remove
+            id: '2009f303-b813-474c-be27-a7469dcc522d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pincurchin remove
+            id: '8cdaa668-1c4f-467f-bd27-2fb1fd2378c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stonjourner remove
+            id: '52a1b9ab-ff77-48f3-8494-09d8773a17d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Indeedee remove
+            id: '60658712-b6ba-4bdd-bae6-d68cb9baf6fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morpeko remove
+            id: '2ede5b2f-253d-49e8-ba06-e00a412dc250',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dracozolt remove
+            id: 'a24b0474-d65d-4601-824f-7f2cefbf52d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arctozolt remove
+            id: '45608793-1fd4-4596-8fa8-51d8ab0205d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dracovish remove
+            id: 'aa85175c-0613-4d07-a465-7b068c3f82ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arctovish remove
+            id: '393d6b71-0af9-4876-b37c-e2470ea37f3c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zacian remove
+            id: 'be49bf03-629c-4b4e-8ea9-e842af3329d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zamazenta remove
+            id: 'efbf2e5b-7941-487f-bd5d-8697988091fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -43,13 +1590,1644 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Lampent remove
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carkol remove
+            id: '7910d776-0f57-4c7e-a254-c242013db56c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sizzlipede remove
+            id: '5b9ca90f-7ad2-45a0-9fe2-e3843323bda6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Centiskorch remove
+            id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rolycoly remove
+            id: '0533fdcd-5e70-4c97-92a0-b1a5ca46af2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ponyta remove
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rapidash remove
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slugma remove
+            id: '1d362a45-b7ce-4a05-9d88-90b330422ab2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magcargo remove
+            id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmortar remove
+            id: '0ca0d2f8-5f6e-443a-aed6-2b6f4902b6ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor (Alolan) remove
+            id: '4008313c-b38d-41c8-a8e1-7b9e5514ca73',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phantump remove
+            id: '4bd98ba2-8bc2-4336-b96a-f4565bc34cc6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arbok remove
+            id: '170e3e80-c88f-4f17-bb00-79079a7548ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snubbull remove
+            id: 'b46b92fc-56f5-4196-bf35-0d7c2e06c9ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Granbull remove
+            id: '435a8d08-9103-4ce6-8336-defcb5573a37',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stantler remove
+            id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mightyena remove
+            id: 'c09c5a3a-6968-4726-8b6f-d79186610d0e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Masquerain remove
+            id: '97f4cf7a-43de-47f9-a734-2b3b5c8870eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staraptor remove
+            id: 'a57ba1c4-7bb7-44cb-89ed-5d6877bee767',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shinx remove
+            id: '8faec058-51ec-472d-80f5-53b37449795c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litten remove
+            id: '1034a515-8e78-4846-8f20-42fcf9bfca6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torracat remove
+            id: '5840a187-de17-4471-b244-d01d6450fac1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deoxys remove
+            id: '3f3c455d-707a-4212-a5d1-c0e743bbd970',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusknoir remove
+            id: '52017eec-3563-4d7b-9845-d4f81a575d2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth (Galarian) remove
+            id: '03d8378d-b4e5-427a-99f7-d6a561b83bb2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndour remove
+            id: 'f050feaa-7a93-499a-b7fc-619d579252a0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Axew remove
+            id: '7d854347-2b2c-48b2-9e9e-3ae1f97fea86',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haxorus remove
+            id: '6eda7ef3-3837-43b2-b2f6-8972aed2ec5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litleo remove
+            id: '283dccaf-97bb-446f-997b-5b74b380a626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyroar remove
+            id: 'bad0a7ce-7718-40d9-8b65-5a43b397794b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bewear remove
+            id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lileep remove
+            id: 'f04cfd6f-6779-43b0-8385-df734442989b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Muk remove
+            id: '3bb72469-4db2-4e94-9dd7-7647fed36c0d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gulpin remove
+            id: 'de4cd6ab-6981-4062-ba93-19b285c9baa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swalot remove
+            id: 'ab2974ee-a499-423b-95b2-1237e6b420dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shellos remove
+            id: '0091eadb-706c-40d1-ba11-5c95b383b46b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trubbish remove
+            id: 'd3dfc5c5-d610-431e-8d99-8575aca5606e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vileplume remove
+            id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weepinbell remove
+            id: 'bb84ab31-c40b-46b2-a60b-09be50ccee67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chikorita remove
+            id: 'dc94125e-f13c-48f0-a142-c01e7df4147f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bayleef remove
+            id: 'f8a8b3fc-eb94-4b78-a49e-006b8e54bafd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meganium remove
+            id: 'fff24eb1-a56d-4730-8160-182ac19f701f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellossom remove
+            id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunflora remove
+            id: '148a6ef8-5d26-42cf-bcfd-48dd25b4a54b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuckle remove
+            id: 'a9056e67-acfe-4264-9f78-06098b5e10dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Teddiursa remove
+            id: '7d45091a-aba7-4f9e-9109-d5b4ec12229f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lotad remove
+            id: '7f1a5f65-a490-4ef6-9add-b4774f56bc84',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Surskit remove
+            id: '81a4fe46-0079-418d-b3c4-882bca5a26e6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Illumise remove
+            id: '0b30f410-05e9-43c2-a11a-ffa941c2eb7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roserade remove
+            id: '67f1990d-2c87-4efa-815f-539a576ceca1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherubi remove
+            id: '19618a6b-e347-49ad-a5d5-08582c8bf817',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snivy remove
+            id: '343d9e67-1f1e-4de6-966f-89bfec09fffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Servine remove
+            id: 'e0358ec5-8afc-478c-b3fa-0ef934854ccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Maractus remove
+            id: '7af0e968-d555-4acb-b030-8fdd64600615',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spritzee remove
+            id: '9d449555-1595-4472-91db-6752abd6722f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aromatisse remove
+            id: '4b81c1c0-bf60-4622-b7af-641ace6b6370',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swirlix remove
+            id: '2f107c3d-5278-4c2d-b6a1-7a4a476402c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slurpuff remove
+            id: '2b1669c2-4caa-4b84-ad5b-59a20894db62',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -95,13 +3273,1004 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cloyster remove
+            id: 'be37c657-0018-4afc-9bab-dde828130189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chikorita remove
+            id: 'dc94125e-f13c-48f0-a142-c01e7df4147f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croconaw remove
+            id: '826e4ab3-34d0-4794-a397-80d98b989c09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chinchou remove
+            id: '4b854817-7f27-4ee5-9dd0-b04a34b8256e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combusken remove
+            id: '629b202a-992f-42f2-88cf-961c4833d0d7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cascoon remove
+            id: '0ae55560-a0fa-4c15-a699-525b09ad844f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacturne remove
+            id: '82fe6639-29b9-4629-873b-9314a2ca4eba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corphish remove
+            id: '5fd6660f-f631-41eb-a4c9-a437e062417c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crawdaunt remove
+            id: 'a36715dd-fc85-4bb0-a9fb-e6ef4eb09a2c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Claydol remove
+            id: '63e0a668-2ce5-458b-9549-8e1181e2c6b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Castform remove
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimecho remove
+            id: '1b2d34e5-43cb-4b4e-ab6d-a876c8b038f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clamperl remove
+            id: '227c8795-30d6-4275-8310-81c7445affb9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketune remove
+            id: '86bc78c6-4450-41c9-b070-87ccadd9b1c2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cranidos remove
+            id: 'd1490924-fe95-4c28-81be-c2e98298b69c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherubi remove
+            id: '19618a6b-e347-49ad-a5d5-08582c8bf817',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chatot remove
+            id: '1a0b6846-d45a-4fd2-98a7-7a3946743e7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Conkeldurr remove
+            id: '993e5d2d-a310-4335-86e3-f65d75523390',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cofagrigus remove
+            id: 'e4b10464-1bed-48bb-9923-d282461c90f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carracosta remove
+            id: '13f93610-2645-4179-aacc-f4b19858f606',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cryogonal remove
+            id: 'e798e439-2d71-4e85-8c9b-1c1e99fe331d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cobalion remove
+            id: 'a4a4529d-cb64-4e76-876f-5c910ba16989',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chespin remove
+            id: '87b11db9-8aeb-44d3-80e1-dd4716d0b705',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chesnaught remove
+            id: '61feae49-3687-451e-92ae-1af275750112',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carbink remove
+            id: 'e11410e2-245b-431c-8ff1-5a6088cf1699',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charjabug remove
+            id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cutiefly remove
+            id: 'f590d249-312f-409a-b606-bbadf1228aa2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmog remove
+            id: 'e4afb300-c937-46bb-9780-f727f77c8f3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmoem remove
+            id: '09144faa-0d83-4276-a7a5-641dfca95c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinderace remove
+            id: 'f88e70fc-6101-49cd-a6b3-570bc4bf4342',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corvisquire remove
+            id: 'b26d0124-b00c-40db-904a-e5c22c4d65be',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corviknight remove
+            id: '0174898b-af6e-471e-8fc1-0127718ec830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chewtle remove
+            id: 'dbed930c-3262-4fff-afca-dd52d4a02bd6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carkol remove
+            id: '7910d776-0f57-4c7e-a254-c242013db56c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Centiskorch remove
+            id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clobbopus remove
+            id: '57535eca-9be6-409c-94b3-7f781a4e2216',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cursola remove
+            id: '7fcac9cf-39aa-41d0-b652-5d1cd636c25f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cufant remove
+            id: 'c1986420-412e-415d-961c-b57bb6f3245c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Copperajah remove
+            id: '5ae94a7c-f5fe-41e4-b89e-68cdb534f313',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kakuna remove
+            id: '62a9662c-9af2-4d47-bfb2-645dcc5c8b59',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krabby remove
+            id: '09c4d189-ee58-44c1-b8c0-9bd51d39dd60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingler remove
+            id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Koffing remove
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingdra remove
+            id: 'e99aa0f1-460c-499f-9c39-0279a7490881',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Karrablast remove
+            id: 'ea5c17dc-4c66-4ccf-96f7-d7de64844bac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klink remove
+            id: '4427bad2-356f-49ea-ade9-9c20ebd9a17b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klang remove
+            id: 'f8022844-958c-46b8-8371-f01195d0701d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klinklang remove
+            id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Komala remove
+            id: '360c0865-0bfc-46dd-807d-2532ddfab4dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -121,13 +4290,184 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♀ remove
+            id: '30f78841-c47a-4bd4-8ee1-f033a0fe758d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wobbuffet remove
+            id: '7c8faea8-5ba1-4c3c-9867-f8f3d9defcd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketune remove
+            id: '86bc78c6-4450-41c9-b070-87ccadd9b1c2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewott remove
+            id: '040027cd-6a60-40cd-8f2b-17775d5e6a1a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tynamo remove
+            id: '7e20ee70-a9eb-4d71-87ff-796131965f57',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshadow remove
+            id: '6d76251d-04a5-40bc-9f62-5e95790703e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mismagius remove
+            id: '44f1c66e-20ec-472b-bb43-daf348daa9bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drilbur remove
+            id: '7d21369d-ef48-4b87-94da-66c0456b60c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vullaby remove
+            id: 'a646d513-ed8b-415b-b371-7653681bebbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Brionne remove
+            id: 'dd947474-1775-416c-829a-197aef7b2f48',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gossifleur remove
+            id: '4b50a13b-39db-41f5-ba0f-9dc65a8c8011',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -147,13 +4487,645 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Eelektrik remove
+            id: '63d99264-97bd-4691-ac15-7927510f07a6',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Wimpod remove
+            id: '794f527e-ee32-4f4d-8b67-12fd54ec7a7b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothita remove
+            id: '571e8806-a993-449a-9d8e-11ce979ca911',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vullaby remove
+            id: 'a646d513-ed8b-415b-b371-7653681bebbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silcoon remove
+            id: '93fe0833-dd33-4735-a8d8-92eb1b63df39',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cascoon remove
+            id: '0ae55560-a0fa-4c15-a699-525b09ad844f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yungoos remove
+            id: 'd1185462-764d-4cd3-90cb-932c34cca0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Timburr remove
+            id: 'f41d0de3-8989-49fc-a56a-57bf68e9e42c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gurdurr remove
+            id: '7d11b7fb-6540-478b-a0e8-d97e5b8fe478',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alomomola remove
+            id: '8499b2ba-b86c-4584-8acc-a2703eee467d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Baltoy remove
+            id: 'aa88be52-a660-4253-ba00-dd6a84e4f73c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steenee remove
+            id: '79652e74-f9a5-486a-af53-aaec0989354e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmoem remove
+            id: '09144faa-0d83-4276-a7a5-641dfca95c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spritzee remove
+            id: '9d449555-1595-4472-91db-6752abd6722f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiploom remove
+            id: '2d4d57dd-0442-4241-b09f-875e07606598',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Patrat remove
+            id: 'b139d84a-aff0-4c49-abc7-c59372cfaab8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sealeo remove
+            id: '414129cc-0302-4d8d-86a0-53dd80451bb2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sewaddle remove
+            id: 'dc27c553-3e13-4dc5-b6d6-241335e5f8d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quilladin remove
+            id: '3e8065f7-1785-4754-b728-f0ec7e6bb094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trumbeak remove
+            id: '8bcf47d2-19f3-4949-bbb5-fbdb7630e665',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purrloin remove
+            id: '6b0dea8a-3f3b-4bd6-af64-8d84649625cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikipek remove
+            id: '30416667-3675-473f-9a38-0eec7c4960ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienfoo remove
+            id: '09657459-fdbb-4e9e-a968-bfef9dc2a5ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meltan remove
+            id: '1b7f2d73-3a74-434a-9c15-b32d3e9229c4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jangmo-o remove
+            id: '3ef6183e-c053-4b59-9be4-194a784c21a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glameow remove
+            id: 'b0fff790-de0b-41fe-b0cd-05117c22b6f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frogadier remove
+            id: 'ad445bbf-ec67-4ded-a608-6a6720d89e61',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fomantis remove
+            id: 'fafe02ee-5ac0-4117-8c76-205ca1f645fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewpider remove
+            id: '8186274b-5267-4752-824a-5fe3233bafbc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ferroseed remove
+            id: 'fbcc31c1-78be-49ee-80a3-a4777eb6b528',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goldeen remove
+            id: 'ae0de176-5c64-4406-b3ba-1b2ef55c6150',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venipede remove
+            id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Huntail remove
+            id: '7163a88e-a933-4183-9797-447656700fe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Karrablast remove
+            id: 'ea5c17dc-4c66-4ccf-96f7-d7de64844bac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelmet remove
+            id: 'f8cd280f-a0ac-497f-bd72-7fffb4fa07b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Panpour remove
+            id: 'dfd21c51-0564-4745-b017-61b1733962b9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansear remove
+            id: 'c4ecec83-9656-4194-8c47-5a5b00c10628',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duosion remove
+            id: '8b5eb318-9fdc-4c69-bfaf-bb0ce21489f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scatterbug remove
+            id: 'de189ff7-1bf7-45ae-a49d-92c28217d44e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phione remove
+            id: '3c1ff9c9-4164-48b4-9f45-f87abdf0f3aa',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -199,13 +5171,315 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Azumarill remove
+            id: '40302532-8dc3-4a8b-9669-5c6f19ae7290',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diggersby remove
+            id: '4a78a20a-2482-4147-8a05-941b29a54914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scorbunny remove
+            id: '04182a98-03e1-4072-84c5-e3c84a6891dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raboot remove
+            id: 'a56639e5-5285-434f-8a73-00c7a61ad873',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinderace remove
+            id: 'f88e70fc-6101-49cd-a6b3-570bc4bf4342',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ducklett remove
+            id: '583cf1b3-ece5-4a89-b07c-24416a748d1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froakie remove
+            id: '9086e1d6-b646-466d-afad-5dcdbb61654e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frogadier remove
+            id: 'ad445bbf-ec67-4ded-a608-6a6720d89e61',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seismitoad remove
+            id: 'd9cd1dea-3557-42e0-b7e4-e7856ed492ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Teddiursa remove
+            id: '7d45091a-aba7-4f9e-9109-d5b4ec12229f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beartic remove
+            id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pancham remove
+            id: '30331ad5-c767-4a20-a5c1-cb10c53979c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stufful remove
+            id: '17983cb6-afed-4379-8f63-65048cc7170b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bewear remove
+            id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -225,13 +5499,525 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wartortle remove
+            id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu (Alolan) remove
+            id: '6ad9fd99-caf8-4209-8d27-c594f71a4016',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales (Alolan) remove
+            id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meltan remove
+            id: '1b7f2d73-3a74-434a-9c15-b32d3e9229c4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Melmetal remove
+            id: '43949067-8499-4c37-b042-afb0b4794c17',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio (Alolan) remove
+            id: '9bbbe3e3-fc68-41da-9148-edecd340a189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett (Alolan) remove
+            id: 'b6d62454-b853-4731-a020-d810f536d7fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth (Alolan) remove
+            id: '52a6f371-58db-451b-bcad-414fbda4ae75',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian (Alolan) remove
+            id: '7d8daf9c-d263-4e36-9d57-702e175ef60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ponyta remove
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rapidash remove
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weezing remove
+            id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon remove
+            id: '05c19863-5bea-446d-8516-f68935e2bdd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone remove
+            id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darumaka remove
+            id: '1bbbb3da-d90e-4cbe-83f1-807358a6d35c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jirachi remove
+            id: 'd81fc796-f8c1-4919-a286-d0d7ceafa0f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litten remove
+            id: '1034a515-8e78-4846-8f20-42fcf9bfca6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torracat remove
+            id: '5840a187-de17-4471-b244-d01d6450fac1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Popplio remove
+            id: '631a2c39-6231-45b3-807c-cd365c5bf995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Brionne remove
+            id: 'dd947474-1775-416c-829a-197aef7b2f48',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primarina remove
+            id: 'f82418ad-7080-4dc7-9036-2ec54cf50a6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cobalion remove
+            id: 'a4a4529d-cb64-4e76-876f-5c910ba16989',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmog remove
+            id: 'e4afb300-c937-46bb-9780-f727f77c8f3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmoem remove
+            id: '09144faa-0d83-4276-a7a5-641dfca95c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshadow remove
+            id: '6d76251d-04a5-40bc-9f62-5e95790703e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -277,13 +6063,1545 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♀ remove
+            id: '30f78841-c47a-4bd4-8ee1-f033a0fe758d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoqueen remove
+            id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Muk remove
+            id: '3bb72469-4db2-4e94-9dd7-7647fed36c0d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hypno remove
+            id: 'e0610027-fbb2-4915-8583-203295d8f06f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Koffing remove
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon remove
+            id: '32db34f7-0c11-401c-8504-d399aa98e376',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omastar remove
+            id: '12dd5353-d2c8-4085-86d0-6ba5d53570fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoothoot remove
+            id: 'bad16e91-df23-422a-a31c-085f9ae09365',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinarak remove
+            id: '16b77d80-6e39-4faf-a51d-0f218fbdc1d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareep remove
+            id: '2d3f45a9-8f6b-4540-9171-037c8a0dac74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowking remove
+            id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon2 remove
+            id: '7fa95f76-105b-45bf-9d9a-00f20329bee3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blaziken remove
+            id: '898e7d9a-3b99-4062-8877-7942532e3adf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon remove
+            id: '05c19863-5bea-446d-8516-f68935e2bdd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dustox remove
+            id: '8b752fd0-5f8a-472c-8aa0-b99ca570cd70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Surskit remove
+            id: '81a4fe46-0079-418d-b3c4-882bca5a26e6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volbeat remove
+            id: 'c0e1b0e4-2b2a-43b8-8d4c-c21c31635bbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swalot remove
+            id: 'ab2974ee-a499-423b-95b2-1237e6b420dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunatone remove
+            id: 'bf708485-a15c-4b56-9c9a-e93731114db0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Anorith remove
+            id: '72b0a709-4c68-4b1d-a423-4e479a4752c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuppet remove
+            id: '01045994-15ba-4f43-9b6c-abfed6a0d7f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Huntail remove
+            id: '7163a88e-a933-4183-9797-447656700fe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Registeel remove
+            id: 'dd83ad95-5524-4d5c-9a9b-dce9210777b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torterra remove
+            id: '16089a5e-4004-4c13-96ad-64197b0b35d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rampardos remove
+            id: 'b591dc28-40ad-48fd-853f-6862161b6a8d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glameow remove
+            id: 'b0fff790-de0b-41fe-b0cd-05117c22b6f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mime Jr. remove
+            id: '758c86f7-e08f-4aa7-ac55-a345669ad53a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gible remove
+            id: '64abb33e-69da-4e81-8468-ed2348ca2369',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lumineon remove
+            id: '05986577-0d49-4e49-9556-4a7c1d681794',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmortar remove
+            id: '0ca0d2f8-5f6e-443a-aed6-2b6f4902b6ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pignite remove
+            id: '04b603e5-8e80-45cd-b1f6-794aa618b5d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purrloin remove
+            id: '6b0dea8a-3f3b-4bd6-af64-8d84649625cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unfezant remove
+            id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zebstrika remove
+            id: '4560393d-0b37-4bb6-9fee-14c6f7929d9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swadloon remove
+            id: '1f85c9c1-6ec1-4062-b8d5-df96564712a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dwebble remove
+            id: '30741c01-f409-4f02-93e7-e8356a8565c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cofagrigus remove
+            id: 'e4b10464-1bed-48bb-9923-d282461c90f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garbodor remove
+            id: 'd828c652-ee3e-4c12-8efb-28b39c06bf52',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solosis remove
+            id: '164b8dbb-dc4b-4855-bdc9-ae5702ed1bba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klink remove
+            id: '4427bad2-356f-49ea-ade9-9c20ebd9a17b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klinklang remove
+            id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienfoo remove
+            id: '09657459-fdbb-4e9e-a968-bfef9dc2a5ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fennekin remove
+            id: 'e23bb748-74bb-43e4-80a5-98e4707c0c27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gogoat remove
+            id: 'a75dbcb8-f58b-49a2-a7b6-99541a74236a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espurr remove
+            id: '2705b76d-489d-4846-b798-0ded376629df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aromatisse remove
+            id: '4b81c1c0-bf60-4622-b7af-641ace6b6370',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diancie remove
+            id: 'd45feb65-7e80-4bc0-92e2-fa817f364fcf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toucannon remove
+            id: '1d94cb81-1be2-4395-bb50-a5b80614ce8b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewpider remove
+            id: '8186274b-5267-4752-824a-5fe3233bafbc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silvally remove
+            id: '2a17f538-45d6-4b40-9baf-bb13311ea493',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Melmetal remove
+            id: '43949067-8499-4c37-b042-afb0b4794c17',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thwackey remove
+            id: '9b7fb41a-f2a7-4a05-b484-8152e50ac922',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rookidee remove
+            id: 'f52a7d08-b297-4564-89a7-a9548f2a00c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corviknight remove
+            id: '0174898b-af6e-471e-8fc1-0127718ec830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nickit remove
+            id: '41d13d7c-7eec-4569-85a9-3625ae72f5b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gossifleur remove
+            id: '4b50a13b-39db-41f5-ba0f-9dc65a8c8011',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grapploct remove
+            id: 'ac67bc65-c761-4cef-87b2-1b4199de77fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hattrem remove
+            id: 'e79f9f7f-4e2c-4672-a01a-22aaef89ae07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Impidimp remove
+            id: '54deb667-a45a-4afc-898e-392d98b33e33',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Perrserker remove
+            id: '504193eb-b52b-453e-969f-cf22bed825df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morpeko remove
+            id: '2ede5b2f-253d-49e8-ba06-e00a412dc250',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arctozolt remove
+            id: '45608793-1fd4-4596-8fa8-51d8ab0205d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arctovish remove
+            id: '393d6b71-0af9-4876-b37c-e2470ea37f3c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragapult remove
+            id: '5597de67-0458-4eee-a571-3ed56febf4ef',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -355,13 +7673,2495 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kakuna remove
+            id: '62a9662c-9af2-4d47-bfb2-645dcc5c8b59',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate remove
+            id: 'dbaea5f9-d1d4-434b-9437-42753792b3d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu (Alolan) remove
+            id: '6ad9fd99-caf8-4209-8d27-c594f71a4016',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash (Alolan) remove
+            id: '0ec6abba-7891-4bae-a6e5-7d9091ba0389',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidorina remove
+            id: '56c615e9-b3a2-442b-b387-5438e9428b29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth (Alolan) remove
+            id: '52a6f371-58db-451b-bcad-414fbda4ae75',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weepinbell remove
+            id: 'bb84ab31-c40b-46b2-a60b-09be50ccee67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem remove
+            id: '09a002b1-b0be-4ca3-82bc-cd26c1bf166f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem (Alolan) remove
+            id: '802f9f76-877e-4a27-866a-fe0273c31c82',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doduo remove
+            id: 'ff3fc630-2a66-40b0-8a1e-e080951984ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Muk (Alolan) remove
+            id: '7843e17c-1b09-4ea8-9984-8ef8976a342f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hypno remove
+            id: 'e0610027-fbb2-4915-8583-203295d8f06f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingler remove
+            id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor (Alolan) remove
+            id: '4008313c-b38d-41c8-a8e1-7b9e5514ca73',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weezing (Galarian) remove
+            id: '55efe1e8-e5fa-4bbe-9c3b-22e710318845',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seaking remove
+            id: '3992362d-ae97-4949-8efc-c4e53483718b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dratini remove
+            id: '5209be64-7255-4973-b665-4734ae773e28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Igglybuff remove
+            id: 'acc70f99-f706-45c5-8a58-989969a970a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunflora remove
+            id: '148a6ef8-5d26-42cf-bcfd-48dd25b4a54b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magcargo remove
+            id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrogue remove
+            id: '6c125504-587f-4831-a1e9-e5bb930859eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mightyena remove
+            id: 'c09c5a3a-6968-4726-8b6f-d79186610d0e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon remove
+            id: '05c19863-5bea-446d-8516-f68935e2bdd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone remove
+            id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cascoon remove
+            id: '0ae55560-a0fa-4c15-a699-525b09ad844f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dustox remove
+            id: '8b752fd0-5f8a-472c-8aa0-b99ca570cd70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Masquerain remove
+            id: '97f4cf7a-43de-47f9-a734-2b3b5c8870eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aggron remove
+            id: '5d6f6deb-a523-431b-9197-2cae11916995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Medicham remove
+            id: '6db5699e-6a48-478e-bc8a-7522e4d7bfbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Illumise remove
+            id: '0b30f410-05e9-43c2-a11a-ffa941c2eb7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grumpig remove
+            id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milotic remove
+            id: '592a7552-99f2-4b46-b214-0b56f31f40c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skuntank remove
+            id: '7fc75ee8-810f-4cee-830f-e24f1c2b3ba4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electivire remove
+            id: 'afdc72cf-5d26-43dc-9e70-f54d68023f80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmortar remove
+            id: '0ca0d2f8-5f6e-443a-aed6-2b6f4902b6ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Probopass remove
+            id: 'dd4e7387-f636-47c8-9eee-062f1d8b4eeb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gigalith remove
+            id: 'cf123990-642b-4761-a494-fd297b0c1c7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Throh remove
+            id: '474d999f-e6d0-493c-8973-66e1c838c291',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillite remove
+            id: '0d326685-c757-4a11-bd85-7c8c63e084e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alomomola remove
+            id: '8499b2ba-b86c-4584-8acc-a2703eee467d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klinklang remove
+            id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eelektross remove
+            id: 'c4eebbc5-667f-4ba1-9fb4-2a1fe5d0d698',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chesnaught remove
+            id: '61feae49-3687-451e-92ae-1af275750112',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Florges remove
+            id: '60cbac1b-57e8-40af-8489-34c92c1c358b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furfrou remove
+            id: '97ac9b43-d8ce-4dfe-a7de-928e87bd9f0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowstic remove
+            id: 'f2d900c2-8d10-4709-b523-cd7c10eb32d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barbaracle remove
+            id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goodra remove
+            id: '36ed9371-57f3-4aef-bd23-47230a25569b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toucannon remove
+            id: '1d94cb81-1be2-4395-bb50-a5b80614ce8b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudsdale remove
+            id: '2b9a4b10-8459-4015-922f-e183751a0349',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fomantis remove
+            id: 'fafe02ee-5ac0-4117-8c76-205ca1f645fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silvally remove
+            id: '2a17f538-45d6-4b40-9baf-bb13311ea493',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Lele remove
+            id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poipole remove
+            id: '14347d15-749b-4dc8-8a19-71da2eabeeb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Melmetal remove
+            id: '43949067-8499-4c37-b042-afb0b4794c17',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rillaboom remove
+            id: '81f20cbc-e206-46cb-8114-65e6a5637fbb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chikorita remove
+            id: 'dc94125e-f13c-48f0-a142-c01e7df4147f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meganium remove
+            id: 'fff24eb1-a56d-4730-8160-182ac19f701f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Totodile remove
+            id: '92d5db27-8ee7-4831-8924-62e9ccbd69a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croconaw remove
+            id: '826e4ab3-34d0-4794-a397-80d98b989c09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feraligatr remove
+            id: '3a6040fd-7480-41f2-a7ad-f03d18f9612a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snubbull remove
+            id: 'b46b92fc-56f5-4196-bf35-0d7c2e06c9ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshtomp remove
+            id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minun remove
+            id: 'a07fae2b-ead4-4ea8-a93a-d3cd43a822b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swablu remove
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Anorith remove
+            id: '72b0a709-4c68-4b1d-a423-4e479a4752c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bagon remove
+            id: '6aa962cb-3176-426d-9a74-f257c805b641',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelgon remove
+            id: 'daaa9487-42ed-46b6-9dcc-f8d323b6c24e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Turtwig remove
+            id: '744a3eb6-8697-4e2d-a813-27ef655491c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grotle remove
+            id: '259a773b-f770-47ec-9459-59bd20cc2711',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roserade remove
+            id: '67f1990d-2c87-4efa-815f-539a576ceca1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        }]
+          ,
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -381,13 +10181,1014 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wartortle remove
+            id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidorino remove
+            id: '07447a2a-9a06-4537-86aa-6d869d1775a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ponyta remove
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingler remove
+            id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lanturn remove
+            id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wobbuffet remove
+            id: '7c8faea8-5ba1-4c3c-9867-f8f3d9defcd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Girafarig remove
+            id: '3b624d92-9f4e-4611-8f39-43683a1740d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Donphan remove
+            id: '3e76a90e-0f4d-41cf-8587-d97415bebfc0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Treecko remove
+            id: 'fb117d92-c93d-4a16-ad9f-ac2062325fa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mightyena remove
+            id: 'c09c5a3a-6968-4726-8b6f-d79186610d0e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volbeat remove
+            id: 'c0e1b0e4-2b2a-43b8-8d4c-c21c31635bbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swablu remove
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Baltoy remove
+            id: 'aa88be52-a660-4253-ba00-dd6a84e4f73c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuppet remove
+            id: '01045994-15ba-4f43-9b6c-abfed6a0d7f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piplup remove
+            id: 'e975c325-8eca-4252-aa82-8433064775c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mothim remove
+            id: 'd7ac1ca8-8090-4f7b-a598-afc6f0849443',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ambipom remove
+            id: '0c43aed8-0b5b-4052-9435-713e64a279ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunky remove
+            id: 'ba3459b2-c4bc-48a7-99fc-ebe206b07017',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon-Z remove
+            id: '55eeff70-26ed-49ec-bcbc-06445a241da7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Panpour remove
+            id: 'dfd21c51-0564-4745-b017-61b1733962b9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tympole remove
+            id: 'e83be142-50c0-481c-9495-843687cf7563',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carracosta remove
+            id: '13f93610-2645-4179-aacc-f4b19858f606',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothorita remove
+            id: '1cda7264-f4aa-4304-86ba-a1cd79ae30cb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deerling remove
+            id: 'de2252f6-ba8f-40f9-98de-c4b725e7bffe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alomomola remove
+            id: '8499b2ba-b86c-4584-8acc-a2703eee467d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelmet remove
+            id: 'f8cd280f-a0ac-497f-bd72-7fffb4fa07b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froakie remove
+            id: '9086e1d6-b646-466d-afad-5dcdbb61654e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vivillon remove
+            id: 'f1c992c4-d94d-42f4-add7-d16864cdea0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furfrou remove
+            id: '97ac9b43-d8ce-4dfe-a7de-928e87bd9f0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrunt remove
+            id: 'f28eb08d-4823-4019-bb92-3a0dde9e0e98',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charjabug remove
+            id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareanie remove
+            id: '77f390a4-0d38-434e-af28-8c858e060b3c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wimpod remove
+            id: '794f527e-ee32-4f4d-8b67-12fd54ec7a7b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togedemaru remove
+            id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meltan remove
+            id: '1b7f2d73-3a74-434a-9c15-b32d3e9229c4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inteleon remove
+            id: '0d817f85-f24c-483a-babf-600f8c024830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thievul remove
+            id: '333868c1-c484-46f9-8a4c-f52e4ce9f60c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carkol remove
+            id: '7910d776-0f57-4c7e-a254-c242013db56c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxel remove
+            id: 'fd557cfa-39b0-4fe4-9d39-131beb026c53',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hatterene remove
+            id: 'f4c23a78-d318-478c-bacc-d2147e4259d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milcery remove
+            id: '487c56e5-9319-46a0-81bb-1666d9219e45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cufant remove
+            id: 'c1986420-412e-415d-961c-b57bb6f3245c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zacian remove
+            id: 'be49bf03-629c-4b4e-8ea9-e842af3329d5',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -407,13 +11208,1114 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '77f7c559-3061-464e-aceb-b6e0e46209ae', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jynx remove
+            id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weepinbell remove
+            id: 'bb84ab31-c40b-46b2-a60b-09be50ccee67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledian remove
+            id: '2979f112-6e54-442f-b55d-5a6d73520fe0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xatu remove
+            id: '6a6d96c4-2935-4fba-9c40-0809aa1858be',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shroomish remove
+            id: 'f20df009-de8b-4983-a8d8-ce86f339b03b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Medicham remove
+            id: '6db5699e-6a48-478e-bc8a-7522e4d7bfbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Banette remove
+            id: 'fad6a4a7-e572-4f07-86ad-39fe31e1ce76',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Loudred remove
+            id: '6f645e2e-98e1-448e-b05f-7d6ba8d24e89',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Numel remove
+            id: 'a409c5b6-da3f-4eaf-9963-ec0b59d5bccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Breloom remove
+            id: '697d384b-63a8-48dc-8722-387534e52750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delcatty remove
+            id: 'b2e08f69-71b5-4f7e-92a0-c2e38d54d300',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifloon remove
+            id: '279b1e2e-4145-4829-9f39-d5e8d2e25a31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon remove
+            id: '05c19863-5bea-446d-8516-f68935e2bdd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furret remove
+            id: 'c29bab69-d99f-40e4-b0a6-cd66bf642472',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blitzle remove
+            id: '39056528-fc4f-4e93-b266-35babab9d386',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seadra remove
+            id: '93c3d7dc-9647-46c9-b957-8d90affc6d09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonair remove
+            id: '64c4d808-c5e9-4227-b9cc-351777fcb591',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wormadam remove
+            id: '14cd8b1e-b0d2-4539-b415-958863c11348',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Patrat remove
+            id: 'b139d84a-aff0-4c49-abc7-c59372cfaab8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidove remove
+            id: '20c0062a-e0b2-4bf5-ae0c-ac4b142c1c54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roggenrola remove
+            id: 'cc0af826-8ee8-426a-bd0b-45bc81f50a1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kakuna remove
+            id: '62a9662c-9af2-4d47-bfb2-645dcc5c8b59',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purrloin remove
+            id: '6b0dea8a-3f3b-4bd6-af64-8d84649625cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munna remove
+            id: '7bf836b2-54e2-456b-9239-08f496fece30',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doduo remove
+            id: 'ff3fc630-2a66-40b0-8a1e-e080951984ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slugma remove
+            id: '1d362a45-b7ce-4a05-9d88-90b330422ab2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poochyena remove
+            id: 'ed1552a1-de0a-4799-87e1-ee0c43ce765d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrike remove
+            id: 'e78d54a8-71cf-4535-ac32-10a0b8abdaad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cofagrigus remove
+            id: 'e4b10464-1bed-48bb-9923-d282461c90f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reuniclus remove
+            id: 'd5aedfb0-d771-4bb3-891f-745a7eee67eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dustox remove
+            id: '8b752fd0-5f8a-472c-8aa0-b99ca570cd70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelgon remove
+            id: 'daaa9487-42ed-46b6-9dcc-f8d323b6c24e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Karrablast remove
+            id: 'ea5c17dc-4c66-4ccf-96f7-d7de64844bac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansage remove
+            id: 'ab32e387-5435-4bc4-86d5-462a8867f1bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansear remove
+            id: 'c4ecec83-9656-4194-8c47-5a5b00c10628',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Panpour remove
+            id: 'dfd21c51-0564-4745-b017-61b1733962b9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deerling remove
+            id: 'de2252f6-ba8f-40f9-98de-c4b725e7bffe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelmet remove
+            id: 'f8cd280f-a0ac-497f-bd72-7fffb4fa07b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jumpluff remove
+            id: 'faddd5f7-0e8c-41fb-9771-2f15fc571bba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiploom remove
+            id: '2d4d57dd-0442-4241-b09f-875e07606598',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellossom remove
+            id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goldeen remove
+            id: 'ae0de176-5c64-4406-b3ba-1b2ef55c6150',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -433,13 +12335,574 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '136dffcb-c364-4d04-96f7-e59d54eb88fb', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azurill remove
+            id: '300ff49a-cc70-4e5d-ac0d-8c3556a69441',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bonsly remove
+            id: '507c9298-b5c6-4314-8f49-10dc43e7ba64',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charjabug remove
+            id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clobbopus remove
+            id: '57535eca-9be6-409c-94b3-7f781a4e2216',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fomantis remove
+            id: 'fafe02ee-5ac0-4117-8c76-205ca1f645fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gligar remove
+            id: '8d04330d-3e11-4191-ab8d-9a5137f8e659',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Happiny remove
+            id: '138e873d-db9b-4f2b-bd9a-59757b9282e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Igglybuff remove
+            id: 'acc70f99-f706-45c5-8a58-989969a970a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone remove
+            id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantyke remove
+            id: '843db6b2-bde6-484e-b3fb-0e813d320062',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meltan remove
+            id: '1b7f2d73-3a74-434a-9c15-b32d3e9229c4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milcery remove
+            id: '487c56e5-9319-46a0-81bb-1666d9219e45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mime Jr. remove
+            id: '758c86f7-e08f-4aa7-ac55-a345669ad53a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pancham remove
+            id: '30331ad5-c767-4a20-a5c1-cb10c53979c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poipole remove
+            id: '14347d15-749b-4dc8-8a19-71da2eabeeb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Riolu remove
+            id: '3063a957-dd1c-4941-8b37-d0984899515b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steenee remove
+            id: '79652e74-f9a5-486a-af53-aaec0989354e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swadloon remove
+            id: '1f85c9c1-6ec1-4062-b8d5-df96564712a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Type: Null remove
+            id: '996e26d4-4a02-462c-988d-6962f176458e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrogue remove
+            id: '6c125504-587f-4831-a1e9-e5bb930859eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrunt remove
+            id: 'f28eb08d-4823-4019-bb92-3a0dde9e0e98',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wurmple remove
+            id: 'c36f780b-5769-407b-9600-921d57ace904',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yungoos remove
+            id: 'd1185462-764d-4cd3-90cb-932c34cca0e8',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -485,13 +12948,554 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♂ remove
+            id: 'bdfe11f4-c8ee-4445-90b5-ea86ac6a4c85',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venonat remove
+            id: 'cac2064e-9c81-4536-80d7-9c39af52113e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drowzee remove
+            id: 'e3d7e9a1-85cf-471c-86ec-18bf93ecefd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feraligatr remove
+            id: '3a6040fd-7480-41f2-a7ad-f03d18f9612a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sunflora remove
+            id: '148a6ef8-5d26-42cf-bcfd-48dd25b4a54b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combusken remove
+            id: '629b202a-992f-42f2-88cf-961c4833d0d7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vigoroth remove
+            id: '5315b47d-b3ca-4175-afeb-7020049d70a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aron remove
+            id: '149b201e-9b77-4c3e-8722-a0be17a89106',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gorebyss remove
+            id: 'd0766277-7803-49a1-8f5c-de6c4d0ffde4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bibarel remove
+            id: '35c540eb-cb16-4d8e-b4d3-2a3f474aae6a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Servine remove
+            id: 'e0358ec5-8afc-478c-b3fa-0ef934854ccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Simisage remove
+            id: '9edae28b-42df-45ee-b38e-5197bcbb8062',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swoobat remove
+            id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whirlipede remove
+            id: 'dd780e01-60cb-46d0-9215-dba1b607a635',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothitelle remove
+            id: '93fac96d-70a5-46a4-b450-0a0491b5130c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lampent remove
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froakie remove
+            id: '9086e1d6-b646-466d-afad-5dcdbb61654e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiddo remove
+            id: '8a099e42-ba65-4365-90d9-2a2bb4966efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goomy remove
+            id: '56c95763-648b-4526-a580-e5f4487c0665',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoopa remove
+            id: '06d0f6c9-6cb0-4b49-b922-d8048d582a2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grubbin remove
+            id: '509fa83d-48c9-441f-9896-143a602e2454',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Araquanid remove
+            id: '99fa0c56-42aa-421c-bb1c-4b264d160f8e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golisopod remove
+            id: 'fa1b3931-846f-458b-9007-7063147c0c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kommo-o remove
+            id: 'bb7e62c5-e6c8-4214-ab20-744381c7fea8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sobble remove
+            id: 'a829996d-61ac-4a55-beac-8197735e7687',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dubwool remove
+            id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxel remove
+            id: 'fd557cfa-39b0-4fe4-9d39-131beb026c53',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cursola remove
+            id: '7fcac9cf-39aa-41d0-b652-5d1cd636c25f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dracozolt remove
+            id: 'a24b0474-d65d-4601-824f-7f2cefbf52d9',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -511,13 +13515,1154 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slugma remove
+            id: '1d362a45-b7ce-4a05-9d88-90b330422ab2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magcargo remove
+            id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lotad remove
+            id: '7f1a5f65-a490-4ef6-9add-b4774f56bc84',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seedot remove
+            id: '791964e7-c59a-4cfe-8f13-caf2c6be8b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Taillow remove
+            id: '3bc05b77-1328-4dff-849d-214826190c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Medicham remove
+            id: '6db5699e-6a48-478e-bc8a-7522e4d7bfbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spoink remove
+            id: '032e251c-554a-4ee0-ac29-ccee98d5b32d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grumpig remove
+            id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swablu remove
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunatone remove
+            id: 'bf708485-a15c-4b56-9c9a-e93731114db0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solrock remove
+            id: 'd71dc002-63ff-4fb6-ad1d-527f48c929d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duskull remove
+            id: 'c374583a-36a8-4325-bf6f-74edbb419845',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regirock remove
+            id: '8fb21e0a-dda9-4abe-9ce8-ee01ce0ff7c5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regice remove
+            id: 'bc9d6986-f768-4988-a37c-f7437709c9d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Registeel remove
+            id: 'dd83ad95-5524-4d5c-9a9b-dce9210777b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latias remove
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deoxys remove
+            id: '3f3c455d-707a-4212-a5d1-c0e743bbd970',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buizel remove
+            id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzor remove
+            id: '6ec12acc-3259-41f2-b18c-0c7df67af075',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snover remove
+            id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusknoir remove
+            id: '52017eec-3563-4d7b-9845-d4f81a575d2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arceus remove
+            id: 'b35607d9-2dce-4ee6-a203-b5c57641297c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dwebble remove
+            id: '30741c01-f409-4f02-93e7-e8356a8565c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ducklett remove
+            id: '583cf1b3-ece5-4a89-b07c-24416a748d1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elgyem remove
+            id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cobalion remove
+            id: 'a4a4529d-cb64-4e76-876f-5c910ba16989',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barbaracle remove
+            id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Helioptile remove
+            id: 'f80c2650-1a54-4f56-ab46-c32cd59ef146',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoopa remove
+            id: '06d0f6c9-6cb0-4b49-b922-d8048d582a2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmog remove
+            id: 'e4afb300-c937-46bb-9780-f727f77c8f3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmoem remove
+            id: '09144faa-0d83-4276-a7a5-641dfca95c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buzzwole remove
+            id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xurkitree remove
+            id: 'b456167a-44ea-4a3f-aacf-e7aa5f4bca5d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poipole remove
+            id: '14347d15-749b-4dc8-8a19-71da2eabeeb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blacephalon remove
+            id: '2009f303-b813-474c-be27-a7469dcc522d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -537,13 +14682,4024 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litten remove
+            id: '1034a515-8e78-4846-8f20-42fcf9bfca6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torracat remove
+            id: '5840a187-de17-4471-b244-d01d6450fac1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Popplio remove
+            id: '631a2c39-6231-45b3-807c-cd365c5bf995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Brionne remove
+            id: 'dd947474-1775-416c-829a-197aef7b2f48',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primarina remove
+            id: 'f82418ad-7080-4dc7-9036-2ec54cf50a6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikipek remove
+            id: '30416667-3675-473f-9a38-0eec7c4960ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trumbeak remove
+            id: '8bcf47d2-19f3-4949-bbb5-fbdb7630e665',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toucannon remove
+            id: '1d94cb81-1be2-4395-bb50-a5b80614ce8b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yungoos remove
+            id: 'd1185462-764d-4cd3-90cb-932c34cca0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gumshoos remove
+            id: '35349d75-66ef-4220-bce0-b60524c29373',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate remove
+            id: 'dbaea5f9-d1d4-434b-9437-42753792b3d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledyba remove
+            id: '87e6d3f7-97a0-4117-ada9-4dcb9d718b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledian remove
+            id: '2979f112-6e54-442f-b55d-5a6d73520fe0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinarak remove
+            id: '16b77d80-6e39-4faf-a51d-0f218fbdc1d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ariados remove
+            id: '291f1a5f-0754-42d4-a21c-286883f9f642',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furfrou remove
+            id: '97ac9b43-d8ce-4dfe-a7de-928e87bd9f0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pichu remove
+            id: '8664bc55-da05-4069-9e68-7512901224ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grubbin remove
+            id: '509fa83d-48c9-441f-9896-143a602e2454',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charjabug remove
+            id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vikavolt remove
+            id: '400b1377-386f-47b5-930e-5bd29e739273',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bonsly remove
+            id: '507c9298-b5c6-4314-8f49-10dc43e7ba64',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Happiny remove
+            id: '138e873d-db9b-4f2b-bd9a-59757b9282e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowking remove
+            id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnezone remove
+            id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Muk remove
+            id: '3bb72469-4db2-4e94-9dd7-7647fed36c0d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mime Jr. remove
+            id: '758c86f7-e08f-4aa7-ac55-a345669ad53a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arbok remove
+            id: '170e3e80-c88f-4f17-bb00-79079a7548ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drowzee remove
+            id: 'e3d7e9a1-85cf-471c-86ec-18bf93ecefd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hypno remove
+            id: 'e0610027-fbb2-4915-8583-203295d8f06f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Makuhita remove
+            id: '40d7919e-766c-4109-a5d1-82444c0b63ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hariyama remove
+            id: 'f2ba8919-95f0-46fc-9053-ce1d1af0bd69',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Smeargle remove
+            id: 'd19a4e77-6a74-496b-b7f7-9ad96e80d6e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifloon remove
+            id: '279b1e2e-4145-4829-9f39-d5e8d2e25a31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifblim remove
+            id: '38e9e1c0-2a92-4ab9-ab1c-aabfb75f8fed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Murkrow remove
+            id: 'b611b2fa-3178-4735-9891-52d9571058bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Honchkrow remove
+            id: '98477623-c2fd-46c2-9fa8-50a2649333f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rufflet remove
+            id: '01346e6f-94e0-41a3-8248-3e6b7f784a04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Braviary remove
+            id: '9b2be3c5-ab6b-4e00-bfaa-6618820b7bde',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vullaby remove
+            id: 'a646d513-ed8b-415b-b371-7653681bebbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mandibuzz remove
+            id: 'fc360160-3e07-4c0a-ad04-05ff31ffada2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primeape remove
+            id: '8b96d379-f31b-4c69-84f0-66f6df3e397f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cutiefly remove
+            id: 'f590d249-312f-409a-b606-bbadf1228aa2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flabébé remove
+            id: 'd750fb34-d294-4862-9c8d-8d04a72570a1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floette remove
+            id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Florges remove
+            id: '60cbac1b-57e8-40af-8489-34c92c1c358b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Smoochum remove
+            id: 'fe4377b2-be91-4308-9401-9d337624ad45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jynx remove
+            id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seel remove
+            id: '3a3d7a26-b94e-49e6-98d7-3d4ba82fb7da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roggenrola remove
+            id: 'cc0af826-8ee8-426a-bd0b-45bc81f50a1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gigalith remove
+            id: 'cf123990-642b-4761-a494-fd297b0c1c7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carbink remove
+            id: 'e11410e2-245b-431c-8ff1-5a6088cf1699',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacool remove
+            id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Finneon remove
+            id: 'dae80cde-8a92-4a23-b9fb-9b0218b34b51',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lumineon remove
+            id: '05986577-0d49-4e49-9556-4a7c1d681794',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wishiwashi remove
+            id: 'e23fab77-2715-434d-b146-4d9664479ffb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareanie remove
+            id: '77f390a4-0d38-434e-af28-8c858e060b3c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxapex remove
+            id: '11c0f865-079c-451a-9007-8285f945d5a3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shellder remove
+            id: '2b76c5cb-cf54-438f-be01-ba2dc3a283d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cloyster remove
+            id: 'be37c657-0018-4afc-9bab-dde828130189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clamperl remove
+            id: '227c8795-30d6-4275-8310-81c7445affb9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Huntail remove
+            id: '7163a88e-a933-4183-9797-447656700fe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gorebyss remove
+            id: 'd0766277-7803-49a1-8f5c-de6c4d0ffde4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantyke remove
+            id: '843db6b2-bde6-484e-b3fb-0e813d320062',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bagon remove
+            id: '6aa962cb-3176-426d-9a74-f257c805b641',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelgon remove
+            id: 'daaa9487-42ed-46b6-9dcc-f8d323b6c24e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sylveon remove
+            id: '461b6f2a-7e72-4476-9593-2375a3b24f4c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareep remove
+            id: '2d3f45a9-8f6b-4540-9171-037c8a0dac74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flaaffy remove
+            id: '0bc1956d-f21f-4b11-ba29-ffcf7c3a2cad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudbray remove
+            id: 'da630920-69c0-4c34-a96e-d39501ff7d1a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudsdale remove
+            id: '2b9a4b10-8459-4015-922f-e183751a0349',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Igglybuff remove
+            id: 'acc70f99-f706-45c5-8a58-989969a970a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Surskit remove
+            id: '81a4fe46-0079-418d-b3c4-882bca5a26e6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Masquerain remove
+            id: '97f4cf7a-43de-47f9-a734-2b3b5c8870eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewpider remove
+            id: '8186274b-5267-4752-824a-5fe3233bafbc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Araquanid remove
+            id: '99fa0c56-42aa-421c-bb1c-4b264d160f8e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fomantis remove
+            id: 'fafe02ee-5ac0-4117-8c76-205ca1f645fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lurantis remove
+            id: 'ac38f23b-110b-40e4-ba52-04823133d826',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiinotic remove
+            id: '72700d35-b5bc-4aa1-b279-4c4e33488e9d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goldeen remove
+            id: 'ae0de176-5c64-4406-b3ba-1b2ef55c6150',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seaking remove
+            id: '3992362d-ae97-4949-8efc-c4e53483718b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milotic remove
+            id: '592a7552-99f2-4b46-b214-0b56f31f40c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alomomola remove
+            id: '8499b2ba-b86c-4584-8acc-a2703eee467d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmortar remove
+            id: '0ca0d2f8-5f6e-443a-aed6-2b6f4902b6ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stufful remove
+            id: '17983cb6-afed-4379-8f63-65048cc7170b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bewear remove
+            id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steenee remove
+            id: '79652e74-f9a5-486a-af53-aaec0989354e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tsareena remove
+            id: '259e43d4-e788-4649-a15f-75e09be096ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoothoot remove
+            id: 'bad16e91-df23-422a-a31c-085f9ae09365',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oranguru remove
+            id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goomy remove
+            id: '56c95763-648b-4526-a580-e5f4487c0665',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goodra remove
+            id: '36ed9371-57f3-4aef-bd23-47230a25569b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Castform remove
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wimpod remove
+            id: '794f527e-ee32-4f4d-8b67-12fd54ec7a7b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golisopod remove
+            id: 'fa1b3931-846f-458b-9007-7063147c0c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omanyte remove
+            id: '0d153819-8caa-4109-8697-269cd778010e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omastar remove
+            id: '12dd5353-d2c8-4085-86d0-6ba5d53570fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lileep remove
+            id: 'f04cfd6f-6779-43b0-8385-df734442989b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Anorith remove
+            id: '72b0a709-4c68-4b1d-a423-4e479a4752c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Armaldo remove
+            id: '15a40976-502d-405e-81bf-0099d3c95b09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cranidos remove
+            id: 'd1490924-fe95-4c28-81be-c2e98298b69c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rampardos remove
+            id: 'b591dc28-40ad-48fd-853f-6862161b6a8d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shieldon remove
+            id: 'c5d23098-25f7-4494-a38c-33fccab7c90b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bastiodon remove
+            id: '754ae45a-c41b-4004-9cc9-f93638145b79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Archen remove
+            id: '1fb90ed9-f7bd-4f08-a970-d34a6c379ce6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Archeops remove
+            id: 'bdbbbc65-62c3-4a70-9f4d-ede5e85f4ba4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tirtouga remove
+            id: '1c53ded7-feab-4825-9621-7135c85ec23f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carracosta remove
+            id: '13f93610-2645-4179-aacc-f4b19858f606',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrunt remove
+            id: 'f28eb08d-4823-4019-bb92-3a0dde9e0e98',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrantrum remove
+            id: 'a7ef88e6-4210-4945-af65-362480932825',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phantump remove
+            id: '4bd98ba2-8bc2-4336-b96a-f4565bc34cc6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xatu remove
+            id: '6a6d96c4-2935-4fba-9c40-0809aa1858be',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Probopass remove
+            id: 'dd4e7387-f636-47c8-9eee-062f1d8b4eeb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chinchou remove
+            id: '4b854817-7f27-4ee5-9dd0-b04a34b8256e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lanturn remove
+            id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Type: Null remove
+            id: '996e26d4-4a02-462c-988d-6962f176458e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silvally remove
+            id: '2a17f538-45d6-4b40-9baf-bb13311ea493',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poipole remove
+            id: '14347d15-749b-4dc8-8a19-71da2eabeeb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trubbish remove
+            id: 'd3dfc5c5-d610-431e-8d99-8575aca5606e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garbodor remove
+            id: 'd828c652-ee3e-4c12-8efb-28b39c06bf52',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minccino remove
+            id: '02e23458-11c2-4351-8669-c60a1948a39a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pineco remove
+            id: 'da602af9-4a1d-40bf-9042-f943f7241a9d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Forretress remove
+            id: '34eb38f2-8d9c-459c-919e-e31ea735695b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elgyem remove
+            id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beldum remove
+            id: 'efe1c7a0-9333-40cf-8017-6a04a9a4187d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metang remove
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon remove
+            id: '32db34f7-0c11-401c-8504-d399aa98e376',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon-Z remove
+            id: '55eeff70-26ed-49ec-bcbc-06445a241da7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pancham remove
+            id: '30331ad5-c767-4a20-a5c1-cb10c53979c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Komala remove
+            id: '360c0865-0bfc-46dd-807d-2532ddfab4dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Turtonator remove
+            id: '3193a867-b51e-407d-9476-5dd9fbe17a6c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndour remove
+            id: 'f050feaa-7a93-499a-b7fc-619d579252a0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togedemaru remove
+            id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrike remove
+            id: 'e78d54a8-71cf-4535-ac32-10a0b8abdaad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electivire remove
+            id: 'afdc72cf-5d26-43dc-9e70-f54d68023f80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem remove
+            id: '09a002b1-b0be-4ca3-82bc-cd26c1bf166f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gible remove
+            id: '64abb33e-69da-4e81-8468-ed2348ca2369',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Baltoy remove
+            id: 'aa88be52-a660-4253-ba00-dd6a84e4f73c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Claydol remove
+            id: '63e0a668-2ce5-458b-9549-8e1181e2c6b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golett remove
+            id: '4e5fc61f-4be5-4088-985f-5d8529e70b44',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golurk remove
+            id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuppet remove
+            id: '01045994-15ba-4f43-9b6c-abfed6a0d7f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Banette remove
+            id: 'fad6a4a7-e572-4f07-86ad-39fe31e1ce76',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bruxish remove
+            id: 'd06db98e-bac0-4676-bf64-0cb0101ef847',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillite remove
+            id: '0d326685-c757-4a11-bd85-7c8c63e084e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillish remove
+            id: '31bd302b-7a8c-42f7-a5c4-c1320ec30f2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanilluxe remove
+            id: 'aeebded8-2b5f-4b4a-8afb-1d0e780d6f29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snubbull remove
+            id: 'b46b92fc-56f5-4196-bf35-0d7c2e06c9ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Granbull remove
+            id: '435a8d08-9103-4ce6-8336-defcb5573a37',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shellos remove
+            id: '0091eadb-706c-40d1-ba11-5c95b383b46b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skrelp remove
+            id: '0b4905b3-bd2f-4714-bbdb-c88474d52b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corphish remove
+            id: '5fd6660f-f631-41eb-a4c9-a437e062417c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crawdaunt remove
+            id: 'a36715dd-fc85-4bb0-a9fb-e6ef4eb09a2c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienfoo remove
+            id: '09657459-fdbb-4e9e-a968-bfef9dc2a5ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienshao remove
+            id: '2fb38bad-ac28-4f28-bab6-10b296873c8c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jangmo-o remove
+            id: '3ef6183e-c053-4b59-9be4-194a784c21a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hakamo-o remove
+            id: '00670562-8c57-4b22-b4dd-56cd18427c55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kommo-o remove
+            id: 'bb7e62c5-e6c8-4214-ab20-744381c7fea8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ambipom remove
+            id: '0c43aed8-0b5b-4052-9435-713e64a279ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litleo remove
+            id: '283dccaf-97bb-446f-997b-5b74b380a626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyroar remove
+            id: 'bad0a7ce-7718-40d9-8b65-5a43b397794b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mismagius remove
+            id: '44f1c66e-20ec-472b-bb43-daf348daa9bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Riolu remove
+            id: '3063a957-dd1c-4941-8b37-d0984899515b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dratini remove
+            id: '5209be64-7255-4973-b665-4734ae773e28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonair remove
+            id: '64c4d808-c5e9-4227-b9cc-351777fcb591',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Lele remove
+            id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmog remove
+            id: 'e4afb300-c937-46bb-9780-f727f77c8f3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cosmoem remove
+            id: '09144faa-0d83-4276-a7a5-641dfca95c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blacephalon remove
+            id: '2009f303-b813-474c-be27-a7469dcc522d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buzzwole remove
+            id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xurkitree remove
+            id: 'b456167a-44ea-4a3f-aacf-e7aa5f4bca5d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magearna remove
+            id: '862b37f7-db2d-400a-ba7d-1a6ed16e29d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshadow remove
+            id: '6d76251d-04a5-40bc-9f62-5e95790703e7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -563,13 +18719,784 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Obstagoon remove
+            id: '2c9c3eff-c528-4c11-b242-3e26ad029538',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omanyte remove
+            id: '0d153819-8caa-4109-8697-269cd778010e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omastar remove
+            id: '12dd5353-d2c8-4085-86d0-6ba5d53570fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oranguru remove
+            id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Orbeetle remove
+            id: 'fc343d87-a7cb-420e-a1b8-e07297d9dbdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oshawott remove
+            id: '1bf76a95-4044-4689-bc8b-d587c347126a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Walrein remove
+            id: '0a3776f1-3b80-478a-aa9f-47c207c94378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wartortle remove
+            id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Watchog remove
+            id: '65da2eae-78bd-429e-bf32-d17943969b12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weepinbell remove
+            id: 'bb84ab31-c40b-46b2-a60b-09be50ccee67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weezing remove
+            id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whirlipede remove
+            id: 'dd780e01-60cb-46d0-9215-dba1b607a635',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wimpod remove
+            id: '794f527e-ee32-4f4d-8b67-12fd54ec7a7b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wishiwashi remove
+            id: 'e23fab77-2715-434d-b146-4d9664479ffb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wobbuffet remove
+            id: '7c8faea8-5ba1-4c3c-9867-f8f3d9defcd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooloo remove
+            id: '82296f48-2914-4e67-8538-8b9c68158cd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wormadam remove
+            id: '14cd8b1e-b0d2-4539-b415-958863c11348',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wurmple remove
+            id: 'c36f780b-5769-407b-9600-921d57ace904',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wynaut remove
+            id: 'd5686b2f-d1c5-4d35-b701-6cba7951b314',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eelektrik remove
+            id: '63d99264-97bd-4691-ac15-7927510f07a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eelektross remove
+            id: 'c4eebbc5-667f-4ba1-9fb4-2a1fe5d0d698',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eldegoss remove
+            id: 'c3c9eace-8d4f-41d6-a4f6-8dec7a789535',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electivire remove
+            id: 'afdc72cf-5d26-43dc-9e70-f54d68023f80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrike remove
+            id: 'e78d54a8-71cf-4535-ac32-10a0b8abdaad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Elgyem remove
+            id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emboar remove
+            id: '392370ea-20a7-4516-86e4-e6c317e99b60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Empoleon remove
+            id: '2097e1f6-3330-4663-8a56-fef5995b075c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Escavalier remove
+            id: 'f2c2f270-4515-40b5-8f42-7a2db6cff048',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espurr remove
+            id: '2705b76d-489d-4846-b798-0ded376629df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Excadrill remove
+            id: '269c4ffc-1add-491b-ab08-b52a47aa912d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nickit remove
+            id: '41d13d7c-7eec-4569-85a9-3625ae72f5b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoking remove
+            id: '4e4201c2-f4b0-4443-8ffe-85f68de3329d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoqueen remove
+            id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♀ remove
+            id: '30f78841-c47a-4bd4-8ee1-f033a0fe758d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♂ remove
+            id: 'bdfe11f4-c8ee-4445-90b5-ea86ac6a4c85',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidorina remove
+            id: '56c615e9-b3a2-442b-b387-5438e9428b29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidorino remove
+            id: '07447a2a-9a06-4537-86aa-6d869d1775a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Numel remove
+            id: 'a409c5b6-da3f-4eaf-9963-ec0b59d5bccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -589,13 +19516,2714 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wartortle remove
+            id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu (Alolan) remove
+            id: '6ad9fd99-caf8-4209-8d27-c594f71a4016',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash (Alolan) remove
+            id: '0ec6abba-7891-4bae-a6e5-7d9091ba0389',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoqueen remove
+            id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoking remove
+            id: '4e4201c2-f4b0-4443-8ffe-85f68de3329d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vileplume remove
+            id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio (Alolan) remove
+            id: '9bbbe3e3-fc68-41da-9148-edecd340a189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian (Alolan) remove
+            id: '7d8daf9c-d263-4e36-9d57-702e175ef60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingler remove
+            id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak (Alolan) remove
+            id: 'f9345b0f-cb75-4347-9be4-bb07233c760b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weezing remove
+            id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weezing (Galarian) remove
+            id: '55efe1e8-e5fa-4bbe-9c3b-22e710318845',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seadra remove
+            id: '93c3d7dc-9647-46c9-b957-8d90affc6d09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seaking remove
+            id: '3992362d-ae97-4949-8efc-c4e53483718b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime (Galarian) remove
+            id: '98edd436-162e-4e9d-ab09-2657ed54052d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jynx remove
+            id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon remove
+            id: '32db34f7-0c11-401c-8504-d399aa98e376',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonair remove
+            id: '64c4d808-c5e9-4227-b9cc-351777fcb591',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lanturn remove
+            id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xatu remove
+            id: '6a6d96c4-2935-4fba-9c40-0809aa1858be',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellossom remove
+            id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azumarill remove
+            id: '40302532-8dc3-4a8b-9669-5c6f19ae7290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowking remove
+            id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grovyle remove
+            id: '9a2ff038-9d5f-4c32-825a-7487003bcbfa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combusken remove
+            id: '629b202a-992f-42f2-88cf-961c4833d0d7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blaziken remove
+            id: '898e7d9a-3b99-4062-8877-7942532e3adf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshtomp remove
+            id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swampert remove
+            id: '019c34ad-99e7-4b8c-a70b-0e2cb34af12f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone remove
+            id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone (Galarian) remove
+            id: '17b37f43-5176-466a-8795-7840cefdfd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lairon remove
+            id: '400afd10-92eb-4e5c-984c-4c61adb9db86',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crawdaunt remove
+            id: 'a36715dd-fc85-4bb0-a9fb-e6ef4eb09a2c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Claydol remove
+            id: '63e0a668-2ce5-458b-9549-8e1181e2c6b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Armaldo remove
+            id: '15a40976-502d-405e-81bf-0099d3c95b09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sealeo remove
+            id: '414129cc-0302-4d8d-86a0-53dd80451bb2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metang remove
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifblim remove
+            id: '38e9e1c0-2a92-4ab9-ab1c-aabfb75f8fed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skuntank remove
+            id: '7fc75ee8-810f-4cee-830f-e24f1c2b3ba4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Liepard remove
+            id: 'a1fd01be-9555-4bf6-a231-68bd6f50250b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Musharna remove
+            id: '48d09eed-1a6a-4faa-b2ce-7b5438e3606c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unfezant remove
+            id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swoobat remove
+            id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gurdurr remove
+            id: '7d11b7fb-6540-478b-a0e8-d97e5b8fe478',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palpitoad remove
+            id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seismitoad remove
+            id: 'd9cd1dea-3557-42e0-b7e4-e7856ed492ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Maractus remove
+            id: '7af0e968-d555-4acb-b030-8fdd64600615',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cofagrigus remove
+            id: 'e4b10464-1bed-48bb-9923-d282461c90f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garbodor remove
+            id: 'd828c652-ee3e-4c12-8efb-28b39c06bf52',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillish remove
+            id: '31bd302b-7a8c-42f7-a5c4-c1320ec30f2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Escavalier remove
+            id: 'f2c2f270-4515-40b5-8f42-7a2db6cff048',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klang remove
+            id: 'f8022844-958c-46b8-8371-f01195d0701d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klinklang remove
+            id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lampent remove
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beartic remove
+            id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cryogonal remove
+            id: 'e798e439-2d71-4e85-8c9b-1c1e99fe331d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk (Galarian) remove
+            id: '3c64e523-a068-49e0-9b62-4cb9c4400965',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienshao remove
+            id: '2fb38bad-ac28-4f28-bab6-10b296873c8c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golurk remove
+            id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diggersby remove
+            id: '4a78a20a-2482-4147-8a05-941b29a54914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doublade remove
+            id: '3c48f457-e591-4fc7-9df1-57dfc5f94589',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barbaracle remove
+            id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrantrum remove
+            id: 'a7ef88e6-4210-4945-af65-362480932825',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gourgeist remove
+            id: '8efb8e70-779f-43f6-b884-e11073accd58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charjabug remove
+            id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vikavolt remove
+            id: '400b1377-386f-47b5-930e-5bd29e739273',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudsdale remove
+            id: '2b9a4b10-8459-4015-922f-e183751a0349',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Araquanid remove
+            id: '99fa0c56-42aa-421c-bb1c-4b264d160f8e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lurantis remove
+            id: 'ac38f23b-110b-40e4-ba52-04823133d826',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiinotic remove
+            id: '72700d35-b5bc-4aa1-b279-4c4e33488e9d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bewear remove
+            id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tsareena remove
+            id: '259e43d4-e788-4649-a15f-75e09be096ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oranguru remove
+            id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togedemaru remove
+            id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greedent remove
+            id: '90db6ec8-9b0e-4891-acbb-a81ac706ab20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Orbeetle remove
+            id: 'fc343d87-a7cb-420e-a1b8-e07297d9dbdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thievul remove
+            id: '333868c1-c484-46f9-8a4c-f52e4ce9f60c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eldegoss remove
+            id: 'c3c9eace-8d4f-41d6-a4f6-8dec7a789535',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dubwool remove
+            id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drednaw remove
+            id: '112a03cb-fe37-4aa4-9b7a-920a8b246339',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boltund remove
+            id: '45ac1a90-8a7e-44dd-8d2c-d8c5e30baaa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carkol remove
+            id: '7910d776-0f57-4c7e-a254-c242013db56c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandaconda remove
+            id: 'd369b94a-fe25-455c-bf84-ec2d73b96b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barraskewda remove
+            id: 'b5638d8e-d19b-470c-b04e-0bca946de8a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxtricity remove
+            id: '0a8f7946-f52a-4530-ac61-edece7ffec32',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Centiskorch remove
+            id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grapploct remove
+            id: 'ac67bc65-c761-4cef-87b2-1b4199de77fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Polteageist remove
+            id: '8f964492-a6ad-4157-991c-abd964de54d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hatterene remove
+            id: 'f4c23a78-d318-478c-bacc-d2147e4259d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimmsnarl remove
+            id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Obstagoon remove
+            id: '2c9c3eff-c528-4c11-b242-3e26ad029538',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Perrserker remove
+            id: '504193eb-b52b-453e-969f-cf22bed825df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alcremie remove
+            id: 'dd6a12bf-c8fc-44d3-8f7f-9666dfc93147',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pincurchin remove
+            id: '8cdaa668-1c4f-467f-bd27-2fb1fd2378c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frosmoth remove
+            id: 'bc130ef1-f6fb-4093-9ebc-32431a57a09d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Indeedee remove
+            id: '60658712-b6ba-4bdd-bae6-d68cb9baf6fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morpeko remove
+            id: '2ede5b2f-253d-49e8-ba06-e00a412dc250',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Copperajah remove
+            id: '5ae94a7c-f5fe-41e4-b89e-68cdb534f313',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duraludon remove
+            id: 'ece1a260-dacb-4e7f-84a0-6f0b92c6fcbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drakloak remove
+            id: '6041715b-b9ff-4fbe-99c9-c6cab724effe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latias remove
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Lele remove
+            id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buzzwole remove
+            id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xurkitree remove
+            id: 'b456167a-44ea-4a3f-aacf-e7aa5f4bca5d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blacephalon remove
+            id: '2009f303-b813-474c-be27-a7469dcc522d',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -615,13 +22243,1414 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: 'fd81057e-5b85-45f9-9cc3-b6d38393a62f', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate remove
+            id: 'dbaea5f9-d1d4-434b-9437-42753792b3d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu (Alolan) remove
+            id: '6ad9fd99-caf8-4209-8d27-c594f71a4016',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett (Alolan) remove
+            id: 'b6d62454-b853-4731-a020-d810f536d7fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio (Alolan) remove
+            id: '9bbbe3e3-fc68-41da-9148-edecd340a189',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth (Galarian) remove
+            id: '03d8378d-b4e5-427a-99f7-d6a561b83bb2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primeape remove
+            id: '8b96d379-f31b-4c69-84f0-66f6df3e397f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem remove
+            id: '09a002b1-b0be-4ca3-82bc-cd26c1bf166f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doduo remove
+            id: 'ff3fc630-2a66-40b0-8a1e-e080951984ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furret remove
+            id: 'c29bab69-d99f-40e4-b0a6-cd66bf642472',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoothoot remove
+            id: 'bad16e91-df23-422a-a31c-085f9ae09365',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Teddiursa remove
+            id: '7d45091a-aba7-4f9e-9109-d5b4ec12229f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stantler remove
+            id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon remove
+            id: '05c19863-5bea-446d-8516-f68935e2bdd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seedot remove
+            id: '791964e7-c59a-4cfe-8f13-caf2c6be8b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shroomish remove
+            id: 'f20df009-de8b-4983-a8d8-ce86f339b03b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slakoth remove
+            id: '41c73fdf-60f6-4139-b418-b226f76199e4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slaking remove
+            id: '8f4452fb-da3a-423e-a0c4-64bed59f5173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hariyama remove
+            id: 'f2ba8919-95f0-46fc-9053-ce1d1af0bd69',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Baltoy remove
+            id: 'aa88be52-a660-4253-ba00-dd6a84e4f73c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regirock remove
+            id: '8fb21e0a-dda9-4abe-9ce8-ee01ce0ff7c5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Infernape remove
+            id: '13c65177-38fd-4987-822f-f76671a94e5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staraptor remove
+            id: 'a57ba1c4-7bb7-44cb-89ed-5d6877bee767',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bibarel remove
+            id: '35c540eb-cb16-4d8e-b4d3-2a3f474aae6a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wormadam remove
+            id: '14cd8b1e-b0d2-4539-b415-958863c11348',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buizel remove
+            id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bonsly remove
+            id: '507c9298-b5c6-4314-8f49-10dc43e7ba64',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Patrat remove
+            id: 'b139d84a-aff0-4c49-abc7-c59372cfaab8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Watchog remove
+            id: '65da2eae-78bd-429e-bf32-d17943969b12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Conkeldurr remove
+            id: '993e5d2d-a310-4335-86e3-f65d75523390',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deerling remove
+            id: 'de2252f6-ba8f-40f9-98de-c4b725e7bffe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sawsbuck remove
+            id: '147eebec-bc96-4ee9-b4dd-3f0a3fc93d91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vullaby remove
+            id: 'a646d513-ed8b-415b-b371-7653681bebbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mandibuzz remove
+            id: 'fc360160-3e07-4c0a-ad04-05ff31ffada2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diggersby remove
+            id: '4a78a20a-2482-4147-8a05-941b29a54914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vivillon remove
+            id: 'f1c992c4-d94d-42f4-add7-d16864cdea0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litleo remove
+            id: '283dccaf-97bb-446f-997b-5b74b380a626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyroar remove
+            id: 'bad0a7ce-7718-40d9-8b65-5a43b397794b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiddo remove
+            id: '8a099e42-ba65-4365-90d9-2a2bb4966efc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gogoat remove
+            id: 'a75dbcb8-f58b-49a2-a7b6-99541a74236a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Honedge remove
+            id: '0633d25c-8f26-4049-8403-407ff49b7a1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doublade remove
+            id: '3c48f457-e591-4fc7-9df1-57dfc5f94589',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barbaracle remove
+            id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skrelp remove
+            id: '0b4905b3-bd2f-4714-bbdb-c88474d52b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrunt remove
+            id: 'f28eb08d-4823-4019-bb92-3a0dde9e0e98',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Phantump remove
+            id: '4bd98ba2-8bc2-4336-b96a-f4565bc34cc6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pumpkaboo remove
+            id: '92f1c2b5-7a27-41e3-98f5-ae7f8ca98d2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gourgeist remove
+            id: '8efb8e70-779f-43f6-b884-e11073accd58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcanion remove
+            id: 'e6295a1b-75b7-42a1-b0b1-a70cb13cf3e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yungoos remove
+            id: 'd1185462-764d-4cd3-90cb-932c34cca0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gumshoos remove
+            id: '35349d75-66ef-4220-bce0-b60524c29373',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudbray remove
+            id: 'da630920-69c0-4c34-a96e-d39501ff7d1a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudsdale remove
+            id: '2b9a4b10-8459-4015-922f-e183751a0349',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skwovet remove
+            id: '2d6d959d-d951-464c-8a99-ebbd693ae643',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greedent remove
+            id: '90db6ec8-9b0e-4891-acbb-a81ac706ab20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nickit remove
+            id: '41d13d7c-7eec-4569-85a9-3625ae72f5b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thievul remove
+            id: '333868c1-c484-46f9-8a4c-f52e4ce9f60c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arrokuda remove
+            id: '436b30c4-6730-4059-a447-cd5b3eb3a48a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barraskewda remove
+            id: 'b5638d8e-d19b-470c-b04e-0bca946de8a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clobbopus remove
+            id: '57535eca-9be6-409c-94b3-7f781a4e2216',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Perrserker remove
+            id: '504193eb-b52b-453e-969f-cf22bed825df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alcremie remove
+            id: 'dd6a12bf-c8fc-44d3-8f7f-9666dfc93147',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -641,13 +23670,904 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venomoth remove
+            id: '9d8e9855-9000-41f9-a4c1-abe4d41fe8c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arbok remove
+            id: '170e3e80-c88f-4f17-bb00-79079a7548ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primeape remove
+            id: '8b96d379-f31b-4c69-84f0-66f6df3e397f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Donphan remove
+            id: '3e76a90e-0f4d-41cf-8587-d97415bebfc0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Makuhita remove
+            id: '40d7919e-766c-4109-a5d1-82444c0b63ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aron remove
+            id: '149b201e-9b77-4c3e-8722-a0be17a89106',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meditite remove
+            id: 'd1c2289a-9425-45b6-9ab7-f4516b860d07',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goldeen remove
+            id: 'ae0de176-5c64-4406-b3ba-1b2ef55c6150',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacool remove
+            id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marill remove
+            id: 'ed377739-ba16-43b7-9292-399ba1dd7d29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buizel remove
+            id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzor remove
+            id: '6ec12acc-3259-41f2-b18c-0c7df67af075',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienfoo remove
+            id: '09657459-fdbb-4e9e-a968-bfef9dc2a5ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rufflet remove
+            id: '01346e6f-94e0-41a3-8248-3e6b7f784a04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vullaby remove
+            id: 'a646d513-ed8b-415b-b371-7653681bebbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Excadrill remove
+            id: '269c4ffc-1add-491b-ab08-b52a47aa912d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Banette remove
+            id: 'fad6a4a7-e572-4f07-86ad-39fe31e1ce76',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golurk remove
+            id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tranquill remove
+            id: 'f7feb66d-f5bd-46fe-ad32-50b3dcd799a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gurdurr remove
+            id: '7d11b7fb-6540-478b-a0e8-d97e5b8fe478',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Throh remove
+            id: '474d999f-e6d0-493c-8973-66e1c838c291',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sawk remove
+            id: '22c654ac-baba-42a6-bc06-49eb9c04029b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuckle remove
+            id: 'a9056e67-acfe-4264-9f78-06098b5e10dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew (Alolan) remove
+            id: '1dc0b2ae-31d4-4759-9908-28efae57fc79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillish remove
+            id: '31bd302b-7a8c-42f7-a5c4-c1320ec30f2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Castform remove
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate (Alolan) remove
+            id: '69f8a248-6531-4f35-88bb-d069d22964b2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gumshoos remove
+            id: '35349d75-66ef-4220-bce0-b60524c29373',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snover remove
+            id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klang remove
+            id: 'f8022844-958c-46b8-8371-f01195d0701d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darumaka (Galarian) remove
+            id: '0f9d997d-62b3-49a7-b5c4-87cc9e2690aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duraludon remove
+            id: 'ece1a260-dacb-4e7f-84a0-6f0b92c6fcbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stonjourner remove
+            id: '52a1b9ab-ff77-48f3-8494-09d8773a17d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime (Galarian) remove
+            id: '98edd436-162e-4e9d-ab09-2657ed54052d',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2020', type: 'year' } }
     }
   }
@@ -666,14 +24586,7 @@ export const competitionsData2020: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2020', type: 'year' } }
     }
   }

--- a/src/data/competitions/2021.data.ts
+++ b/src/data/competitions/2021.data.ts
@@ -17,13 +17,784 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Regieleki remove
+            id: '1d12f572-4220-40c6-a5ce-fd19e9eeaa84',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Deoxys remove
+            id: '3f3c455d-707a-4212-a5d1-c0e743bbd970',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragapult remove
+            id: '5597de67-0458-4eee-a571-3ed56febf4ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barraskewda remove
+            id: 'b5638d8e-d19b-470c-b04e-0bca946de8a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darmanitan (Galarian) remove
+            id: '089e11a9-9131-4ae7-9492-df34ddffaa11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boltund remove
+            id: '45ac1a90-8a7e-44dd-8d2c-d8c5e30baaa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inteleon remove
+            id: '0d817f85-f24c-483a-babf-600f8c024830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinderace remove
+            id: 'f88e70fc-6101-49cd-a6b3-570bc4bf4342',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zebstrika remove
+            id: '4560393d-0b37-4bb6-9fee-14c6f7929d9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ambipom remove
+            id: '0c43aed8-0b5b-4052-9435-713e64a279ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swoobat remove
+            id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jumpluff remove
+            id: 'faddd5f7-0e8c-41fb-9771-2f15fc571bba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latias remove
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gallade remove
+            id: '34f1dd7b-5470-4203-9abe-93ce7bc49442',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Archeops remove
+            id: 'bdbbbc65-62c3-4a70-9f4d-ede5e85f4ba4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Infernape remove
+            id: '13c65177-38fd-4987-822f-f76671a94e5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian (Alolan) remove
+            id: '7d8daf9c-d263-4e36-9d57-702e175ef60a',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -43,13 +814,734 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morpeko remove
+            id: '2ede5b2f-253d-49e8-ba06-e00a412dc250',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wobbuffet remove
+            id: '7c8faea8-5ba1-4c3c-9867-f8f3d9defcd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Indeedee remove
+            id: '60658712-b6ba-4bdd-bae6-d68cb9baf6fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Regirock remove
+            id: '8fb21e0a-dda9-4abe-9ce8-ee01ce0ff7c5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stonjourner remove
+            id: '52a1b9ab-ff77-48f3-8494-09d8773a17d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zacian remove
+            id: 'be49bf03-629c-4b4e-8ea9-e842af3329d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zamazenta remove
+            id: 'efbf2e5b-7941-487f-bd5d-8697988091fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rillaboom remove
+            id: '81f20cbc-e206-46cb-8114-65e6a5637fbb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cinderace remove
+            id: 'f88e70fc-6101-49cd-a6b3-570bc4bf4342',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inteleon remove
+            id: '0d817f85-f24c-483a-babf-600f8c024830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxtricity remove
+            id: '0a8f7946-f52a-4530-ac61-edece7ffec32',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Polteageist remove
+            id: '8f964492-a6ad-4157-991c-abd964de54d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eldegoss remove
+            id: 'c3c9eace-8d4f-41d6-a4f6-8dec7a789535',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milotic remove
+            id: '592a7552-99f2-4b46-b214-0b56f31f40c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pincurchin remove
+            id: '8cdaa668-1c4f-467f-bd27-2fb1fd2378c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragapult remove
+            id: '5597de67-0458-4eee-a571-3ed56febf4ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandaconda remove
+            id: 'd369b94a-fe25-455c-bf84-ec2d73b96b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Copperajah remove
+            id: '5ae94a7c-f5fe-41e4-b89e-68cdb534f313',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dubwool remove
+            id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Centiskorch remove
+            id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vikavolt remove
+            id: '400b1377-386f-47b5-930e-5bd29e739273',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro (Galarian) remove
+            id: 'af9d2920-db55-4d2a-aedf-d090f0578f7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimmsnarl remove
+            id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk (Galarian) remove
+            id: '3c64e523-a068-49e0-9b62-4cb9c4400965',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sirfetch'd remove
+            id: '14a0090a-50cd-4934-8fc5-228775adf3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drednaw remove
+            id: '112a03cb-fe37-4aa4-9b7a-920a8b246339',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cursola remove
+            id: '7fcac9cf-39aa-41d0-b652-5d1cd636c25f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alcremie remove
+            id: 'dd6a12bf-c8fc-44d3-8f7f-9666dfc93147',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grapploct remove
+            id: 'ac67bc65-c761-4cef-87b2-1b4199de77fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duraludon remove
+            id: 'ece1a260-dacb-4e7f-84a0-6f0b92c6fcbf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Orbeetle remove
+            id: 'fc343d87-a7cb-420e-a1b8-e07297d9dbdf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zarude remove
+            id: '0636fc26-cf46-4850-b481-711546e3d76f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darmanitan (Galarian) remove
+            id: '089e11a9-9131-4ae7-9492-df34ddffaa11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togekiss remove
+            id: '8f95aee6-776a-4df8-9c67-86ec9c7345d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greedent remove
+            id: '90db6ec8-9b0e-4891-acbb-a81ac706ab20',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -95,13 +1587,354 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'dba308cb-887e-4db2-913a-3a80caacd932', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skitty remove
+            id: '89d387dd-40b4-4323-9511-05bf19ec2c6c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spoink remove
+            id: '032e251c-554a-4ee0-ac29-ccee98d5b32d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milotic remove
+            id: '592a7552-99f2-4b46-b214-0b56f31f40c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metang remove
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bibarel remove
+            id: '35c540eb-cb16-4d8e-b4d3-2a3f474aae6a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifloon remove
+            id: '279b1e2e-4145-4829-9f39-d5e8d2e25a31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gallade remove
+            id: '34f1dd7b-5470-4203-9abe-93ce7bc49442',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emboar remove
+            id: '392370ea-20a7-4516-86e4-e6c317e99b60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothorita remove
+            id: '1cda7264-f4aa-4304-86ba-a1cd79ae30cb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klang remove
+            id: 'f8022844-958c-46b8-8371-f01195d0701d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chespin remove
+            id: '87b11db9-8aeb-44d3-80e1-dd4716d0b705',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sylveon remove
+            id: '461b6f2a-7e72-4476-9593-2375a3b24f4c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litten remove
+            id: '1034a515-8e78-4846-8f20-42fcf9bfca6b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mudsdale remove
+            id: '2b9a4b10-8459-4015-922f-e183751a0349',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Komala remove
+            id: '360c0865-0bfc-46dd-807d-2532ddfab4dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dottler remove
+            id: '9e8225af-8228-47b3-b21f-9526dc9e7c0d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sizzlipede remove
+            id: '5b9ca90f-7ad2-45a0-9fe2-e3843323bda6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -121,13 +1954,1034 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kakuna remove
+            id: '62a9662c-9af2-4d47-bfb2-645dcc5c8b59',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoqueen remove
+            id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vileplume remove
+            id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primeape remove
+            id: '8b96d379-f31b-4c69-84f0-66f6df3e397f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Doduo remove
+            id: 'ff3fc630-2a66-40b0-8a1e-e080951984ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Muk remove
+            id: '3bb72469-4db2-4e94-9dd7-7647fed36c0d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingler remove
+            id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xatu remove
+            id: '6a6d96c4-2935-4fba-9c40-0809aa1858be',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marill remove
+            id: 'ed377739-ba16-43b7-9292-399ba1dd7d29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiploom remove
+            id: '2d4d57dd-0442-4241-b09f-875e07606598',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Teddiursa remove
+            id: '7d45091a-aba7-4f9e-9109-d5b4ec12229f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stantler remove
+            id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cascoon remove
+            id: '0ae55560-a0fa-4c15-a699-525b09ad844f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Taillow remove
+            id: '3bc05b77-1328-4dff-849d-214826190c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Masquerain remove
+            id: '97f4cf7a-43de-47f9-a734-2b3b5c8870eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azurill remove
+            id: '300ff49a-cc70-4e5d-ac0d-8c3556a69441',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimecho remove
+            id: '1b2d34e5-43cb-4b4e-ab6d-a876c8b038f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Huntail remove
+            id: '7163a88e-a933-4183-9797-447656700fe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bagon remove
+            id: '6aa962cb-3176-426d-9a74-f257c805b641',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shelgon remove
+            id: 'daaa9487-42ed-46b6-9dcc-f8d323b6c24e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Turtwig remove
+            id: '744a3eb6-8697-4e2d-a813-27ef655491c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torterra remove
+            id: '16089a5e-4004-4c13-96ad-64197b0b35d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzor remove
+            id: '6ec12acc-3259-41f2-b18c-0c7df67af075',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mime Jr. remove
+            id: '758c86f7-e08f-4aa7-ac55-a345669ad53a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansage remove
+            id: 'ab32e387-5435-4bc4-86d5-462a8867f1bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Simisage remove
+            id: '9edae28b-42df-45ee-b38e-5197bcbb8062',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munna remove
+            id: '7bf836b2-54e2-456b-9239-08f496fece30',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unfezant remove
+            id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Archen remove
+            id: '1fb90ed9-f7bd-4f08-a970-d34a6c379ce6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eelektrik remove
+            id: '63d99264-97bd-4691-ac15-7927510f07a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zweilous remove
+            id: 'f5374f2f-62e7-4881-9cbc-a12c18c37050',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meloetta remove
+            id: 'ad7f8437-dc5d-4ecd-af94-e54190abdba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chesnaught remove
+            id: '61feae49-3687-451e-92ae-1af275750112',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -173,13 +3027,394 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drowzee remove
+            id: 'e3d7e9a1-85cf-471c-86ec-18bf93ecefd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krabby remove
+            id: '09c4d189-ee58-44c1-b8c0-9bd51d39dd60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Horsea remove
+            id: 'fe5ce1b9-1969-4c11-8e30-1fbbda7c59af',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dratini remove
+            id: '5209be64-7255-4973-b665-4734ae773e28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skitty remove
+            id: '89d387dd-40b4-4323-9511-05bf19ec2c6c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delcatty remove
+            id: 'b2e08f69-71b5-4f7e-92a0-c2e38d54d300',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jirachi remove
+            id: 'd81fc796-f8c1-4919-a286-d0d7ceafa0f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cherubi remove
+            id: '19618a6b-e347-49ad-a5d5-08582c8bf817',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunky remove
+            id: 'ba3459b2-c4bc-48a7-99fc-ebe206b07017',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Happiny remove
+            id: '138e873d-db9b-4f2b-bd9a-59757b9282e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon-Z remove
+            id: '55eeff70-26ed-49ec-bcbc-06445a241da7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -199,13 +3434,294 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swablu remove
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silicobra remove
+            id: '353ea629-d1a0-4a1a-8ea9-c633a2588ad2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandaconda remove
+            id: 'd369b94a-fe25-455c-bf84-ec2d73b96b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gigalith remove
+            id: 'cf123990-642b-4761-a494-fd297b0c1c7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales (Alolan) remove
+            id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snover remove
+            id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanilluxe remove
+            id: 'aeebded8-2b5f-4b4a-8afb-1d0e780d6f29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -225,13 +3741,2344 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Vivillon remove
+            id: 'f1c992c4-d94d-42f4-add7-d16864cdea0f',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Pichu remove
+            id: '8664bc55-da05-4069-9e68-7512901224ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grookey remove
+            id: '3ca532e9-3cb5-44f4-b157-08ce4b3bf578',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scorbunny remove
+            id: '04182a98-03e1-4072-84c5-e3c84a6891dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wurmple remove
+            id: 'c36f780b-5769-407b-9600-921d57ace904',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Murkrow remove
+            id: 'b611b2fa-3178-4735-9891-52d9571058bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ducklett remove
+            id: '583cf1b3-ece5-4a89-b07c-24416a748d1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Taillow remove
+            id: '3bc05b77-1328-4dff-849d-214826190c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torterra remove
+            id: '16089a5e-4004-4c13-96ad-64197b0b35d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoothoot remove
+            id: 'bad16e91-df23-422a-a31c-085f9ae09365',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Florges remove
+            id: '60cbac1b-57e8-40af-8489-34c92c1c358b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sylveon remove
+            id: '461b6f2a-7e72-4476-9593-2375a3b24f4c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meganium remove
+            id: 'fff24eb1-a56d-4730-8160-182ac19f701f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cutiefly remove
+            id: 'f590d249-312f-409a-b606-bbadf1228aa2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trubbish remove
+            id: 'd3dfc5c5-d610-431e-8d99-8575aca5606e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arbok remove
+            id: '170e3e80-c88f-4f17-bb00-79079a7548ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikipek remove
+            id: '30416667-3675-473f-9a38-0eec7c4960ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toucannon remove
+            id: '1d94cb81-1be2-4395-bb50-a5b80614ce8b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ariados remove
+            id: '291f1a5f-0754-42d4-a21c-286883f9f642',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slaking remove
+            id: '8f4452fb-da3a-423e-a0c4-64bed59f5173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Liepard remove
+            id: 'a1fd01be-9555-4bf6-a231-68bd6f50250b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swampert remove
+            id: '019c34ad-99e7-4b8c-a70b-0e2cb34af12f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledian remove
+            id: '2979f112-6e54-442f-b55d-5a6d73520fe0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sobble remove
+            id: 'a829996d-61ac-4a55-beac-8197735e7687',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espurr remove
+            id: '2705b76d-489d-4846-b798-0ded376629df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deerling remove
+            id: 'de2252f6-ba8f-40f9-98de-c4b725e7bffe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sawsbuck remove
+            id: '147eebec-bc96-4ee9-b4dd-3f0a3fc93d91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unfezant remove
+            id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pancham remove
+            id: '30331ad5-c767-4a20-a5c1-cb10c53979c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Applin remove
+            id: '568746c3-51f1-4050-bbe7-66829f09e3df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bewear remove
+            id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lotad remove
+            id: '7f1a5f65-a490-4ef6-9add-b4774f56bc84',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Milotic remove
+            id: '592a7552-99f2-4b46-b214-0b56f31f40c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifblim remove
+            id: '38e9e1c0-2a92-4ab9-ab1c-aabfb75f8fed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zangoose remove
+            id: '62d87f95-80cd-4313-9791-a7fd201c97d4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellossom remove
+            id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stunfisk remove
+            id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Finneon remove
+            id: 'dae80cde-8a92-4a23-b9fb-9b0218b34b51',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clamperl remove
+            id: '227c8795-30d6-4275-8310-81c7445affb9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Primarina remove
+            id: 'f82418ad-7080-4dc7-9036-2ec54cf50a6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailord remove
+            id: '07ff75e6-351d-46d2-9c12-50fc64cf9854',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareanie remove
+            id: '77f390a4-0d38-434e-af28-8c858e060b3c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luvdisc remove
+            id: '4d010bb8-bba9-4a1d-b2cc-b0acc3836da1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alomomola remove
+            id: '8499b2ba-b86c-4584-8acc-a2703eee467d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cradily remove
+            id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lumineon remove
+            id: '05986577-0d49-4e49-9556-4a7c1d681794',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chinchou remove
+            id: '4b854817-7f27-4ee5-9dd0-b04a34b8256e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lanturn remove
+            id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golisopod remove
+            id: 'fa1b3931-846f-458b-9007-7063147c0c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wishiwashi remove
+            id: 'e23fab77-2715-434d-b146-4d9664479ffb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mandibuzz remove
+            id: 'fc360160-3e07-4c0a-ad04-05ff31ffada2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Silicobra remove
+            id: '353ea629-d1a0-4a1a-8ea9-c633a2588ad2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torchic remove
+            id: 'da4d8b9a-edbc-4521-a783-ce83551a912e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shinx remove
+            id: '8faec058-51ec-472d-80f5-53b37449795c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyrantrum remove
+            id: 'a7ef88e6-4210-4945-af65-362480932825',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Archeops remove
+            id: 'bdbbbc65-62c3-4a70-9f4d-ede5e85f4ba4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slugma remove
+            id: '1d362a45-b7ce-4a05-9d88-90b330422ab2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Furret remove
+            id: 'c29bab69-d99f-40e4-b0a6-cd66bf642472',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beartic remove
+            id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mightyena remove
+            id: 'c09c5a3a-6968-4726-8b6f-d79186610d0e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Braviary remove
+            id: '9b2be3c5-ab6b-4e00-bfaa-6618820b7bde',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frosmoth remove
+            id: 'bc130ef1-f6fb-4093-9ebc-32431a57a09d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jynx remove
+            id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piplup remove
+            id: 'e975c325-8eca-4252-aa82-8433064775c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanilluxe remove
+            id: 'aeebded8-2b5f-4b4a-8afb-1d0e780d6f29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Avalugg remove
+            id: '06e87530-bdd5-41cd-8a70-197d8f70035a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carbink remove
+            id: 'e11410e2-245b-431c-8ff1-5a6088cf1699',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pumpkaboo remove
+            id: '92f1c2b5-7a27-41e3-98f5-ae7f8ca98d2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drifloon remove
+            id: '279b1e2e-4145-4829-9f39-d5e8d2e25a31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rampardos remove
+            id: 'b591dc28-40ad-48fd-853f-6862161b6a8d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Goodra remove
+            id: '36ed9371-57f3-4aef-bd23-47230a25569b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diancie remove
+            id: 'd45feb65-7e80-4bc0-92e2-fa817f364fcf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eldegoss remove
+            id: 'c3c9eace-8d4f-41d6-a4f6-8dec7a789535',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sigilyph remove
+            id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golurk remove
+            id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jirachi remove
+            id: 'd81fc796-f8c1-4919-a286-d0d7ceafa0f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shroomish remove
+            id: 'f20df009-de8b-4983-a8d8-ce86f339b03b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Feraligatr remove
+            id: '3a6040fd-7480-41f2-a7ad-f03d18f9612a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drilbur remove
+            id: '7d21369d-ef48-4b87-94da-66c0456b60c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tepig remove
+            id: '6f4622b1-d9c5-41a9-b83b-970743131a7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gliscor remove
+            id: 'ac359f44-f9a8-427f-922f-b980f3dc755d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Koffing remove
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swalot remove
+            id: 'ab2974ee-a499-423b-95b2-1237e6b420dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -253,13 +6100,474 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Horsea remove
+            id: 'fe5ce1b9-1969-4c11-8e30-1fbbda7c59af',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Chikorita remove
+            id: 'dc94125e-f13c-48f0-a142-c01e7df4147f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Totodile remove
+            id: '92d5db27-8ee7-4831-8924-62e9ccbd69a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klink remove
+            id: '4427bad2-356f-49ea-ade9-9c20ebd9a17b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marill remove
+            id: 'ed377739-ba16-43b7-9292-399ba1dd7d29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venipede remove
+            id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothita remove
+            id: '571e8806-a993-449a-9d8e-11ce979ca911',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Honedge remove
+            id: '0633d25c-8f26-4049-8403-407ff49b7a1d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vigoroth remove
+            id: '5315b47d-b3ca-4175-afeb-7020049d70a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duosion remove
+            id: '8b5eb318-9fdc-4c69-bfaf-bb0ce21489f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Axew remove
+            id: '7d854347-2b2c-48b2-9e9e-3ae1f97fea86',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togekiss remove
+            id: '8f95aee6-776a-4df8-9c67-86ec9c7345d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emboar remove
+            id: '392370ea-20a7-4516-86e4-e6c317e99b60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Conkeldurr remove
+            id: '993e5d2d-a310-4335-86e3-f65d75523390',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leavanny remove
+            id: '9133efd4-b663-43a4-ac24-877bc38c8da8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eelektross remove
+            id: 'c4eebbc5-667f-4ba1-9fb4-2a1fe5d0d698',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scatterbug remove
+            id: 'de189ff7-1bf7-45ae-a49d-92c28217d44e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combusken remove
+            id: '629b202a-992f-42f2-88cf-961c4833d0d7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grovyle remove
+            id: '9a2ff038-9d5f-4c32-825a-7487003bcbfa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshtomp remove
+            id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Prinplup remove
+            id: 'a05f33d0-472a-4db2-b6ff-a683c52101a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grotle remove
+            id: '259a773b-f770-47ec-9459-59bd20cc2711',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aggron remove
+            id: '5d6f6deb-a523-431b-9197-2cae11916995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chesnaught remove
+            id: '61feae49-3687-451e-92ae-1af275750112',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delphox remove
+            id: 'a2416331-b97d-49d5-84ca-758cfbd9f74e',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -279,13 +6587,524 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♀ remove
+            id: '30f78841-c47a-4bd4-8ee1-f033a0fe758d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zangoose remove
+            id: '62d87f95-80cd-4313-9791-a7fd201c97d4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chatot remove
+            id: '1a0b6846-d45a-4fd2-98a7-7a3946743e7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledyba remove
+            id: '87e6d3f7-97a0-4117-ada9-4dcb9d718b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minun remove
+            id: 'a07fae2b-ead4-4ea8-a93a-d3cd43a822b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gossifleur remove
+            id: '4b50a13b-39db-41f5-ba0f-9dc65a8c8011',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solrock remove
+            id: 'd71dc002-63ff-4fb6-ad1d-527f48c929d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett (Alolan) remove
+            id: 'b6d62454-b853-4731-a020-d810f536d7fa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seedot remove
+            id: '791964e7-c59a-4cfe-8f13-caf2c6be8b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blipbug remove
+            id: '5da2230d-4843-47e8-8ac0-f877f1814a58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Torchic remove
+            id: 'da4d8b9a-edbc-4521-a783-ce83551a912e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krabby remove
+            id: '09c4d189-ee58-44c1-b8c0-9bd51d39dd60',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Genesect remove
+            id: '5a304b6a-7ceb-4063-bd14-5a7d4cae5812',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Illumise remove
+            id: '0b30f410-05e9-43c2-a11a-ffa941c2eb7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beldum remove
+            id: 'efe1c7a0-9333-40cf-8017-6a04a9a4187d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Minccino remove
+            id: '02e23458-11c2-4351-8669-c60a1948a39a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -331,13 +7150,384 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Houndour remove
+            id: 'f050feaa-7a93-499a-b7fc-619d579252a0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grumpig remove
+            id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimecho remove
+            id: '1b2d34e5-43cb-4b4e-ab6d-a876c8b038f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Turtwig remove
+            id: '744a3eb6-8697-4e2d-a813-27ef655491c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buizel remove
+            id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darumaka remove
+            id: '1bbbb3da-d90e-4cbe-83f1-807358a6d35c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Braviary remove
+            id: '9b2be3c5-ab6b-4e00-bfaa-6618820b7bde',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vanillite remove
+            id: '0d326685-c757-4a11-bd85-7c8c63e084e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pancham remove
+            id: '30331ad5-c767-4a20-a5c1-cb10c53979c6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Trevenant remove
+            id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Crabrawler remove
+            id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -357,13 +7547,174 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Minun remove
+            id: 'a07fae2b-ead4-4ea8-a93a-d3cd43a822b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Horsea remove
+            id: 'fe5ce1b9-1969-4c11-8e30-1fbbda7c59af',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Woobat remove
+            id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatmor remove
+            id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimecho remove
+            id: '1b2d34e5-43cb-4b4e-ab6d-a876c8b038f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tympole remove
+            id: 'e83be142-50c0-481c-9495-843687cf7563',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Throh remove
+            id: '474d999f-e6d0-493c-8973-66e1c838c291',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sawk remove
+            id: '22c654ac-baba-42a6-bc06-49eb9c04029b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nidoran♂ remove
+            id: 'bdfe11f4-c8ee-4445-90b5-ea86ac6a4c85',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -383,12 +7734,289 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
             type: 'pokemon'
           }
         }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales (Alolan) remove
+            id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rapidash (Galarian) remove
+            id: '27bbd20e-454f-436c-a55a-07a32afbbb64',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        }
+      ,
+          
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        }
+      ,
+            
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Polteageist remove
+            id: '8f964492-a6ad-4157-991c-abd964de54d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golisopod remove
+            id: 'fa1b3931-846f-458b-9007-7063147c0c49',
+            type: 'pokemon'
+          }
+        }      
       ],
       year: { data: { id: '2021', type: 'year' } }
     }
@@ -409,13 +8037,1824 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Aggron remove
+            id: '5d6f6deb-a523-431b-9197-2cae11916995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor (Alolan) remove
+            id: '4008313c-b38d-41c8-a8e1-7b9e5514ca73',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude (Alolan) remove
+            id: 'df82c137-ce8e-45ec-9856-3ba2854d3e3f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem (Alolan) remove
+            id: '802f9f76-877e-4a27-866a-fe0273c31c82',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales (Alolan) remove
+            id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate (Alolan) remove
+            id: '69f8a248-6531-4f35-88bb-d069d22964b2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew (Alolan) remove
+            id: '1dc0b2ae-31d4-4759-9908-28efae57fc79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash (Alolan) remove
+            id: '0ec6abba-7891-4bae-a6e5-7d9091ba0389',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Appletun remove
+            id: '7e8e5d61-57e7-4378-a66d-e84f3f21f0ee',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Applin remove
+            id: '568746c3-51f1-4050-bbe7-66829f09e3df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aron remove
+            id: '149b201e-9b77-4c3e-8722-a0be17a89106',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barbaracle remove
+            id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bastiodon remove
+            id: '754ae45a-c41b-4004-9cc9-f93638145b79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Breloom remove
+            id: '697d384b-63a8-48dc-8722-387534e52750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buzzwole remove
+            id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cacturne remove
+            id: '82fe6639-29b9-4629-873b-9314a2ca4eba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Calyrex remove
+            id: 'c99809ef-a138-4554-9532-6e0367b9128e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carbink remove
+            id: 'e11410e2-245b-431c-8ff1-5a6088cf1699',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carkol remove
+            id: '7910d776-0f57-4c7e-a254-c242013db56c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carracosta remove
+            id: '13f93610-2645-4179-aacc-f4b19858f606',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Centiskorch remove
+            id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chesnaught remove
+            id: '61feae49-3687-451e-92ae-1af275750112',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Corsola remove
+            id: '4b1f380b-3d86-4add-aad6-87abb6f173c0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diancie remove
+            id: 'd45feb65-7e80-4bc0-92e2-fa817f364fcf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Drednaw remove
+            id: '112a03cb-fe37-4aa4-9b7a-920a8b246339',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ducklett remove
+            id: '583cf1b3-ece5-4a89-b07c-24416a748d1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Escavalier remove
+            id: 'f2c2f270-4515-40b5-8f42-7a2db6cff048',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ferroseed remove
+            id: 'fbcc31c1-78be-49ee-80a3-a4777eb6b528',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ferrothorn remove
+            id: '0b80d2e6-a425-47b7-baba-b7109da9e17b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flapple remove
+            id: 'a4ec17ef-d300-4cf1-95f3-a0d060f790ef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Forretress remove
+            id: '34eb38f2-8d9c-459c-919e-e31ea735695b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Frosmoth remove
+            id: 'bc130ef1-f6fb-4093-9ebc-32431a57a09d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Linoone (Galarian) remove
+            id: '17b37f43-5176-466a-8795-7840cefdfd6e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zigzagoon (Galarian) remove
+            id: '8fea1dc6-e4a7-437b-8411-872c8158c939',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Genesect remove
+            id: '5a304b6a-7ceb-4063-bd14-5a7d4cae5812',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gible remove
+            id: '64abb33e-69da-4e81-8468-ed2348ca2369',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gligar remove
+            id: '8d04330d-3e11-4191-ab8d-9a5137f8e659',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gliscor remove
+            id: 'ac359f44-f9a8-427f-922f-b980f3dc755d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golem remove
+            id: '09a002b1-b0be-4ca3-82bc-cd26c1bf166f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hakamo-o remove
+            id: '00670562-8c57-4b22-b4dd-56cd18427c55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoopa remove
+            id: '06d0f6c9-6cb0-4b49-b922-d8048d582a2e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hoppip remove
+            id: '45458f0f-3118-4b87-a148-bee667717bc2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jumpluff remove
+            id: 'faddd5f7-0e8c-41fb-9771-2f15fc571bba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kommo-o remove
+            id: 'bb7e62c5-e6c8-4214-ab20-744381c7fea8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lairon remove
+            id: '400afd10-92eb-4e5c-984c-4c61adb9db86',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leavanny remove
+            id: '9133efd4-b663-43a4-ac24-877bc38c8da8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledian remove
+            id: '2979f112-6e54-442f-b55d-5a6d73520fe0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ledyba remove
+            id: '87e6d3f7-97a0-4117-ada9-4dcb9d718b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magcargo remove
+            id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnezone remove
+            id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantyke remove
+            id: '843db6b2-bde6-484e-b3fb-0e813d320062',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marshtomp remove
+            id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Masquerain remove
+            id: '97f4cf7a-43de-47f9-a734-2b3b5c8870eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mothim remove
+            id: 'd7ac1ca8-8090-4f7b-a598-afc6f0849443',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Numel remove
+            id: 'a409c5b6-da3f-4eaf-9963-ec0b59d5bccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Obstagoon remove
+            id: '2c9c3eff-c528-4c11-b242-3e26ad029538',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omanyte remove
+            id: '0d153819-8caa-4109-8697-269cd778010e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Omastar remove
+            id: '12dd5353-d2c8-4085-86d0-6ba5d53570fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palpitoad remove
+            id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pangoro remove
+            id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Probopass remove
+            id: 'dd4e7387-f636-47c8-9eee-062f1d8b4eeb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seismitoad remove
+            id: 'd9cd1dea-3557-42e0-b7e4-e7856ed492ec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sewaddle remove
+            id: 'dc27c553-3e13-4dc5-b6d6-241335e5f8d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shieldon remove
+            id: 'c5d23098-25f7-4494-a38c-33fccab7c90b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shiinotic remove
+            id: '72700d35-b5bc-4aa1-b279-4c4e33488e9d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sizzlipede remove
+            id: '5b9ca90f-7ad2-45a0-9fe2-e3843323bda6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skiploom remove
+            id: '2d4d57dd-0442-4241-b09f-875e07606598',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snover remove
+            id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stakataka remove
+            id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swadloon remove
+            id: '1f85c9c1-6ec1-4062-b8d5-df96564712a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swampert remove
+            id: '019c34ad-99e7-4b8c-a70b-0e2cb34af12f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swanna remove
+            id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tapu Bulu remove
+            id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tirtouga remove
+            id: '1c53ded7-feab-4825-9621-7135c85ec23f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togedemaru remove
+            id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxel remove
+            id: 'fd557cfa-39b0-4fe4-9d39-131beb026c53',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Toxtricity remove
+            id: '0a8f7946-f52a-4530-ac61-edece7ffec32',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tropius remove
+            id: 'd89bcb1c-7129-483b-9ff4-6de0b5566505',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Urshifu remove
+            id: '5da303c7-e2b2-47ee-be17-51812f0609d5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vivillon remove
+            id: 'f1c992c4-d94d-42f4-add7-d16864cdea0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wormadam remove
+            id: '14cd8b1e-b0d2-4539-b415-958863c11348',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zarude remove
+            id: '0636fc26-cf46-4850-b481-711546e3d76f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zweilous remove
+            id: 'f5374f2f-62e7-4881-9cbc-a12c18c37050',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ratatta (Alolan) remove
+            id: '1a636f2b-e354-496d-9ae1-07de7d69ec7e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Graveller (Alolan) remove
+            id: '64be93c6-3d42-4ec5-a5f7-90e0345eb6ba',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -435,12 +9874,2714 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
+
+          {
+            data: {
+              // Ivysaur remove
+              id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+              type: 'pokemon'
+            }
           }
-        }
+        ,
+        
+        
+          {
+            data: {
+              // Charmeleon remove
+              id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Wartortle remove
+              id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Butterfree remove
+              id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Raichu remove
+              id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Raichu (Alolan) remove
+              id: '6ad9fd99-caf8-4209-8d27-c594f71a4016',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sandslash remove
+              id: '9aa32524-9860-4da9-9873-01b69cec5811',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sandslash (Alolan) remove
+              id: '0ec6abba-7891-4bae-a6e5-7d9091ba0389',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Nidoqueen remove
+              id: '6751bb05-524f-4fd4-b5f0-d519d990207b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Nidoking remove
+              id: '4e4201c2-f4b0-4443-8ffe-85f68de3329d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Clefairy remove
+              id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Clefable remove
+              id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Jigglypuff remove
+              id: 'f250f876-d7b7-4c70-96db-736582008619',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Wigglytuff remove
+              id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Gloom remove
+              id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Vileplume remove
+              id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dugtrio remove
+              id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dugtrio (Alolan) remove
+              id: '9bbbe3e3-fc68-41da-9148-edecd340a189',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Persian remove
+              id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Persian (Alolan) remove
+              id: '7d8daf9c-d263-4e36-9d57-702e175ef60a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Golduck remove
+              id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Poliwrath remove
+              id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kadabra remove
+              id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Machoke remove
+              id: '1737b066-12bc-4df4-9041-8e62872058d8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tentacruel remove
+              id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Slowbro remove
+              id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Magneton remove
+              id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Haunter remove
+              id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kingler remove
+              id: '040eca75-cda3-4812-ad11-50f126a9ef18',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Exeggutor remove
+              id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Marowak remove
+              id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Marowak (Alolan) remove
+              id: 'f9345b0f-cb75-4347-9be4-bb07233c760b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Hitmonlee remove
+              id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Hitmonchan remove
+              id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lickitung remove
+              id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Weezing remove
+              id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Weezing (Galarian) remove
+              id: '55efe1e8-e5fa-4bbe-9c3b-22e710318845',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Rhydon remove
+              id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Chansey remove
+              id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tangela remove
+              id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kangaskhan remove
+              id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Seadra remove
+              id: '93c3d7dc-9647-46c9-b957-8d90affc6d09',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Seaking remove
+              id: '3992362d-ae97-4949-8efc-c4e53483718b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Starmie remove
+              id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mr. Mime remove
+              id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mr. Mime (Galarian) remove
+              id: '98edd436-162e-4e9d-ab09-2657ed54052d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Scyther remove
+              id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Jynx remove
+              id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Electabuzz remove
+              id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Magmar remove
+              id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tauros remove
+              id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Ditto remove
+              id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Vaporeon remove
+              id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Jolteon remove
+              id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Flareon remove
+              id: '832750ec-e083-4096-9dc8-c38121d64a68',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Porygon remove
+              id: '32db34f7-0c11-401c-8504-d399aa98e376',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dragonair remove
+              id: '64c4d808-c5e9-4227-b9cc-351777fcb591',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Noctowl remove
+              id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lanturn remove
+              id: 'd032e256-4fbf-44d0-bafd-98c2dc656d94',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Togetic remove
+              id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Xatu remove
+              id: '6a6d96c4-2935-4fba-9c40-0809aa1858be',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Bellossom remove
+              id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Azumarill remove
+              id: '40302532-8dc3-4a8b-9669-5c6f19ae7290',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sudowoodo remove
+              id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Politoed remove
+              id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Quagsire remove
+              id: '90753663-6eaf-460f-b3df-a56773333783',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Slowking remove
+              id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dunsparce remove
+              id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Qwilfish remove
+              id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sneasel remove
+              id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Piloswine remove
+              id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Octillery remove
+              id: '968ac154-1faa-4628-9364-03381d65b61a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mantine remove
+              id: '90d58436-5903-4459-9e87-210b8b2d2750',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Skarmory remove
+              id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Hitmontop remove
+              id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Miltank remove
+              id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Grovyle remove
+              id: '9a2ff038-9d5f-4c32-825a-7487003bcbfa',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sceptile remove
+              id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Combusken remove
+              id: '629b202a-992f-42f2-88cf-961c4833d0d7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Blaziken remove
+              id: '898e7d9a-3b99-4062-8877-7942532e3adf',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Marshtomp remove
+              id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Swampert remove
+              id: '019c34ad-99e7-4b8c-a70b-0e2cb34af12f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Linoone remove
+              id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Linoone (Galarian) remove
+              id: '17b37f43-5176-466a-8795-7840cefdfd6e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Pelipper remove
+              id: '8d36fc6e-c19c-41de-a990-02e218113832',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Ninjask remove
+              id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Exploud remove
+              id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lairon remove
+              id: '400afd10-92eb-4e5c-984c-4c61adb9db86',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Manectric remove
+              id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Roselia remove
+              id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sharpedo remove
+              id: '6513c390-9859-42e3-9cb4-bf114605597d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Wailmer remove
+              id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Torkoal remove
+              id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Flygon remove
+              id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Altaria remove
+              id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Whiscash remove
+              id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Crawdaunt remove
+              id: 'a36715dd-fc85-4bb0-a9fb-e6ef4eb09a2c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Claydol remove
+              id: '63e0a668-2ce5-458b-9549-8e1181e2c6b5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cradily remove
+              id: 'db8c0d86-b3fe-4f12-9a5e-ce780951b858',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Armaldo remove
+              id: '15a40976-502d-405e-81bf-0099d3c95b09',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dusclops remove
+              id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Absol remove
+              id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Glalie remove
+              id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sealeo remove
+              id: '414129cc-0302-4d8d-86a0-53dd80451bb2',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Relicanth remove
+              id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Metang remove
+              id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Luxray remove
+              id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Vespiquen remove
+              id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cherrim remove
+              id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Gastrodon remove
+              id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Drifblim remove
+              id: '38e9e1c0-2a92-4ab9-ab1c-aabfb75f8fed',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lopunny remove
+              id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Skuntank remove
+              id: '7fc75ee8-810f-4cee-830f-e24f1c2b3ba4',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Bronzong remove
+              id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Munchlax remove
+              id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Drapion remove
+              id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Abomasnow remove
+              id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Froslass remove
+              id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Rotom remove
+              id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Stoutland remove
+              id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Liepard remove
+              id: 'a1fd01be-9555-4bf6-a231-68bd6f50250b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Musharna remove
+              id: '48d09eed-1a6a-4faa-b2ce-7b5438e3606c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Unfezant remove
+              id: 'f041b102-085f-4aae-b536-7e6cce7c8383',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Boldore remove
+              id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Swoobat remove
+              id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Audino remove
+              id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Gurdurr remove
+              id: '7d11b7fb-6540-478b-a0e8-d97e5b8fe478',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Palpitoad remove
+              id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Seismitoad remove
+              id: 'd9cd1dea-3557-42e0-b7e4-e7856ed492ec',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Scolipede remove
+              id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Whimsicott remove
+              id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lilligant remove
+              id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Basculin remove
+              id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Krookodile remove
+              id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Maractus remove
+              id: '7af0e968-d555-4acb-b030-8fdd64600615',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Crustle remove
+              id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sigilyph remove
+              id: '2b3bdf14-d2fe-491b-857b-b6b973cc5d27',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cofagrigus remove
+              id: 'e4b10464-1bed-48bb-9923-d282461c90f9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Garbodor remove
+              id: 'd828c652-ee3e-4c12-8efb-28b39c06bf52',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cinccino remove
+              id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Vanillish remove
+              id: '31bd302b-7a8c-42f7-a5c4-c1320ec30f2e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Emolga remove
+              id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Escavalier remove
+              id: 'f2c2f270-4515-40b5-8f42-7a2db6cff048',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Amoonguss remove
+              id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Jellicent remove
+              id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Galvantula remove
+              id: '488d87d2-36ee-4472-a001-6d99ca709846',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Klang remove
+              id: 'f8022844-958c-46b8-8371-f01195d0701d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Klinklang remove
+              id: '05d5d6f1-0c74-4448-abb5-53484aee8f2d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Beheeyem remove
+              id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lampent remove
+              id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Fraxure remove
+              id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Beartic remove
+              id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cryogonal remove
+              id: 'e798e439-2d71-4e85-8c9b-1c1e99fe331d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Accelgor remove
+              id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Stunfisk remove
+              id: '93ed080d-1513-49b7-9347-5a031b49b90d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Stunfisk (Galarian) remove
+              id: '3c64e523-a068-49e0-9b62-4cb9c4400965',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mienshao remove
+              id: '2fb38bad-ac28-4f28-bab6-10b296873c8c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Druddigon remove
+              id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Golurk remove
+              id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Bisharp remove
+              id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Bouffalant remove
+              id: '423f263c-aed0-4b24-be99-11de2ac70290',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Heatmor remove
+              id: 'cd348243-8335-4ba4-842a-714d7c3c4ce7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Durant remove
+              id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Diggersby remove
+              id: '4a78a20a-2482-4147-8a05-941b29a54914',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Talonflame remove
+              id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Pangoro remove
+              id: '22592007-9cc0-4060-bab0-9eb2db455ac8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Doublade remove
+              id: '3c48f457-e591-4fc7-9df1-57dfc5f94589',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Malamar remove
+              id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Barbaracle remove
+              id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Heliolisk remove
+              id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tyrantrum remove
+              id: 'a7ef88e6-4210-4945-af65-362480932825',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Aurorus remove
+              id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Hawlucha remove
+              id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dedenne remove
+              id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Klefki remove
+              id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Trevenant remove
+              id: 'b60b7b3d-ce80-4664-9645-d0c5cb81212a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Gourgeist remove
+              id: '8efb8e70-779f-43f6-b884-e11073accd58',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Charjabug remove
+              id: '30a00a27-8dea-4bba-9104-287cd00394f8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Vikavolt remove
+              id: '400b1377-386f-47b5-930e-5bd29e739273',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Ribombee remove
+              id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lycanroc remove
+              id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mudsdale remove
+              id: '2b9a4b10-8459-4015-922f-e183751a0349',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Araquanid remove
+              id: '99fa0c56-42aa-421c-bb1c-4b264d160f8e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lurantis remove
+              id: 'ac38f23b-110b-40e4-ba52-04823133d826',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Shiinotic remove
+              id: '72700d35-b5bc-4aa1-b279-4c4e33488e9d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Salazzle remove
+              id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Bewear remove
+              id: '12a959c4-dd94-44a2-b81d-a9cd67a2680b',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tsareena remove
+              id: '259e43d4-e788-4649-a15f-75e09be096ca',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Comfey remove
+              id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Oranguru remove
+              id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Passimian remove
+              id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Palossand remove
+              id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Pyukumuku remove
+              id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Togedemaru remove
+              id: '67f968c4-60ec-476d-b655-cd1a7d68d8ad',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mimikyu remove
+              id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Greedent remove
+              id: '90db6ec8-9b0e-4891-acbb-a81ac706ab20',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Orbeetle remove
+              id: 'fc343d87-a7cb-420e-a1b8-e07297d9dbdf',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Thievul remove
+              id: '333868c1-c484-46f9-8a4c-f52e4ce9f60c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Eldegoss remove
+              id: 'c3c9eace-8d4f-41d6-a4f6-8dec7a789535',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dubwool remove
+              id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Drednaw remove
+              id: '112a03cb-fe37-4aa4-9b7a-920a8b246339',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Boltund remove
+              id: '45ac1a90-8a7e-44dd-8d2c-d8c5e30baaa9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Carkol remove
+              id: '7910d776-0f57-4c7e-a254-c242013db56c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Coalossal remove
+              id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Sandaconda remove
+              id: 'd369b94a-fe25-455c-bf84-ec2d73b96b9a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cramorant remove
+              id: '772314d7-ca25-457c-9f30-531f979b521c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Barraskewda remove
+              id: 'b5638d8e-d19b-470c-b04e-0bca946de8a9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Toxtricity remove
+              id: '0a8f7946-f52a-4530-ac61-edece7ffec32',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Centiskorch remove
+              id: 'fd93d458-525a-45cc-ab7f-c1d31b86e2ea',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Grapploct remove
+              id: 'ac67bc65-c761-4cef-87b2-1b4199de77fa',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Polteageist remove
+              id: '8f964492-a6ad-4157-991c-abd964de54d3',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Hatterene remove
+              id: 'f4c23a78-d318-478c-bacc-d2147e4259d5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Grimmsnarl remove
+              id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Obstagoon remove
+              id: '2c9c3eff-c528-4c11-b242-3e26ad029538',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Perrserker remove
+              id: '504193eb-b52b-453e-969f-cf22bed825df',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Alcremie remove
+              id: 'dd6a12bf-c8fc-44d3-8f7f-9666dfc93147',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Falinks remove
+              id: 'a47be34b-890b-4260-b54f-565162e3300d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Pincurchin remove
+              id: '8cdaa668-1c4f-467f-bd27-2fb1fd2378c7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Frosmoth remove
+              id: 'bc130ef1-f6fb-4093-9ebc-32431a57a09d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Indeedee remove
+              id: '60658712-b6ba-4bdd-bae6-d68cb9baf6fa',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Morpeko remove
+              id: '2ede5b2f-253d-49e8-ba06-e00a412dc250',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Copperajah remove
+              id: '5ae94a7c-f5fe-41e4-b89e-68cdb534f313',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Duraludon remove
+              id: 'ece1a260-dacb-4e7f-84a0-6f0b92c6fcbf',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Drakloak remove
+              id: '6041715b-b9ff-4fbe-99c9-c6cab724effe',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Articuno remove
+              id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Zapdos remove
+              id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Moltres remove
+              id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mewtwo remove
+              id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Raikou remove
+              id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Entei remove
+              id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Suicune remove
+              id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lugia remove
+              id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Ho-oh remove
+              id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Latias remove
+              id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Latios remove
+              id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kyogre remove
+              id: '3bb1a893-8647-4227-8624-874b958f7e74',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Groudon remove
+              id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Rayquaza remove
+              id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Uxie remove
+              id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Mesprit remove
+              id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Azelf remove
+              id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Dialga remove
+              id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Palkia remove
+              id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Heatran remove
+              id: '16b10976-e656-46d4-becb-eddc4093a33e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Giratina remove
+              id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Cresselia remove
+              id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tornadus remove
+              id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Thundurus remove
+              id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Reshiram remove
+              id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Zekrom remove
+              id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Landorus remove
+              id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kyurem remove
+              id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Xerneas remove
+              id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Yveltal remove
+              id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Zygarde remove
+              id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tapu Koko remove
+              id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tapu Lele remove
+              id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tapu Bulu remove
+              id: 'dea75710-4952-4e5d-a524-02da9a8484c8',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Tapu Fini remove
+              id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Solgaleo remove
+              id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Lunala remove
+              id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Nihilego remove
+              id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Buzzwole remove
+              id: '76c86be1-39f7-4a86-a0e6-8effcd890168',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Pheromosa remove
+              id: '5999866a-9753-4d47-a267-01751c3617c7',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Xurkitree remove
+              id: 'b456167a-44ea-4a3f-aacf-e7aa5f4bca5d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Celesteela remove
+              id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Kartana remove
+              id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Guzzlord remove
+              id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Necrozma remove
+              id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Stakataka remove
+              id: '678325b0-fa1f-4a08-b499-3fa02a3f2b2d',
+              type: 'pokemon'
+            }
+          }
+        ,
+        
+        
+          {
+            data: {
+              // Blacephalon remove
+              id: '2009f303-b813-474c-be27-a7469dcc522d',
+              type: 'pokemon'
+            }
+          }
       ],
       year: { data: { id: '2021', type: 'year' } }
     }
@@ -461,13 +12602,1064 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Slowpoke (Galarian) remove
+            id: '11bb00ef-40ed-47ae-9b04-e543c60e48fc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowbro (Galarian) remove
+            id: 'af9d2920-db55-4d2a-aedf-d090f0578f7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Slowking remove
+            id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Happiny remove
+            id: '138e873d-db9b-4f2b-bd9a-59757b9282e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Igglybuff remove
+            id: 'acc70f99-f706-45c5-8a58-989969a970a4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fomantis remove
+            id: 'fafe02ee-5ac0-4117-8c76-205ca1f645fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lurantis remove
+            id: 'ac38f23b-110b-40e4-ba52-04823133d826',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shinx remove
+            id: '8faec058-51ec-472d-80f5-53b37449795c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacool remove
+            id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Druddigon remove
+            id: '0baa377e-800e-4313-aa01-c0d510fa8508',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venipede remove
+            id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whirlipede remove
+            id: 'dd780e01-60cb-46d0-9215-dba1b607a635',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magnezone remove
+            id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azurill remove
+            id: '300ff49a-cc70-4e5d-ac0d-8c3556a69441',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marill remove
+            id: 'ed377739-ba16-43b7-9292-399ba1dd7d29',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Azumarill remove
+            id: '40302532-8dc3-4a8b-9669-5c6f19ae7290',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Loudred remove
+            id: '6f645e2e-98e1-448e-b05f-7d6ba8d24e89',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienfoo remove
+            id: '09657459-fdbb-4e9e-a968-bfef9dc2a5ca',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mienshao remove
+            id: '2fb38bad-ac28-4f28-bab6-10b296873c8c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew (Alolan) remove
+            id: '1dc0b2ae-31d4-4759-9908-28efae57fc79',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash (Alolan) remove
+            id: '0ec6abba-7891-4bae-a6e5-7d9091ba0389',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skrelp remove
+            id: '0b4905b3-bd2f-4714-bbdb-c88474d52b6f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Horsea remove
+            id: 'fe5ce1b9-1969-4c11-8e30-1fbbda7c59af',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seadra remove
+            id: '93c3d7dc-9647-46c9-b957-8d90affc6d09',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kingdra remove
+            id: 'e99aa0f1-460c-499f-9c39-0279a7490881',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor (Alolan) remove
+            id: '4008313c-b38d-41c8-a8e1-7b9e5514ca73',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon remove
+            id: '32db34f7-0c11-401c-8504-d399aa98e376',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Porygon-Z remove
+            id: '55eeff70-26ed-49ec-bcbc-06445a241da7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magearna remove
+            id: '862b37f7-db2d-400a-ba7d-1a6ed16e29d2',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -487,13 +13679,444 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: 'ff4976ce-1519-4ad6-a124-eef49565fc58', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Ivysaur remove
+            id: '62830ee2-2d39-4f4f-850d-1a6e385858f4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wartortle remove
+            id: 'd55761ec-1938-4deb-bcd9-159f4d752b01',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kakuna remove
+            id: '62a9662c-9af2-4d47-bfb2-645dcc5c8b59',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raticate remove
+            id: 'dbaea5f9-d1d4-434b-9437-42753792b3d2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandslash remove
+            id: '9aa32524-9860-4da9-9873-01b69cec5811',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vileplume remove
+            id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -513,13 +14136,1094 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '1e665730-88cd-4ca3-b03c-961c3a71e749', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Arceus remove
+            id: 'b35607d9-2dce-4ee6-a203-b5c57641297c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Jigglypuff remove
+            id: 'f250f876-d7b7-4c70-96db-736582008619',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Wigglytuff remove
+            id: '8bcaf26c-feb0-45db-b688-0a427b7e7a7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Infernape remove
+            id: '13c65177-38fd-4987-822f-f76671a94e5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Reshiram remove
+            id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Oshawott remove
+            id: '1bf76a95-4044-4689-bc8b-d587c347126a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dewott remove
+            id: '040027cd-6a60-40cd-8f2b-17775d5e6a1a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shinx remove
+            id: '8faec058-51ec-472d-80f5-53b37449795c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snivy remove
+            id: '343d9e67-1f1e-4de6-966f-89bfec09fffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Servine remove
+            id: 'e0358ec5-8afc-478c-b3fa-0ef934854ccd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gurdurr remove
+            id: '7d11b7fb-6540-478b-a0e8-d97e5b8fe478',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Conkeldurr remove
+            id: '993e5d2d-a310-4335-86e3-f65d75523390',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rufflet remove
+            id: '01346e6f-94e0-41a3-8248-3e6b7f784a04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Braviary remove
+            id: '9b2be3c5-ab6b-4e00-bfaa-6618820b7bde',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gallade remove
+            id: '34f1dd7b-5470-4203-9abe-93ce7bc49442',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pineco remove
+            id: 'da602af9-4a1d-40bf-9042-f943f7241a9d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Forretress remove
+            id: '34eb38f2-8d9c-459c-919e-e31ea735695b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roggenrola remove
+            id: 'cc0af826-8ee8-426a-bd0b-45bc81f50a1c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gigalith remove
+            id: 'cf123990-642b-4761-a494-fd297b0c1c7f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mismagius remove
+            id: '44f1c66e-20ec-472b-bb43-daf348daa9bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aron remove
+            id: '149b201e-9b77-4c3e-8722-a0be17a89106',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lairon remove
+            id: '400afd10-92eb-4e5c-984c-4c61adb9db86',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aggron remove
+            id: '5d6f6deb-a523-431b-9197-2cae11916995',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Registeel remove
+            id: 'dd83ad95-5524-4d5c-9a9b-dce9210777b0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mareep remove
+            id: '2d3f45a9-8f6b-4540-9171-037c8a0dac74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duskull remove
+            id: 'c374583a-36a8-4325-bf6f-74edbb419845',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lampent remove
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Staraptor remove
+            id: 'a57ba1c4-7bb7-44cb-89ed-5d6877bee767',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Munna remove
+            id: '7bf836b2-54e2-456b-9239-08f496fece30',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothita remove
+            id: '571e8806-a993-449a-9d8e-11ce979ca911',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothorita remove
+            id: '1cda7264-f4aa-4304-86ba-a1cd79ae30cb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gothitelle remove
+            id: '93fac96d-70a5-46a4-b450-0a0491b5130c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scrafty remove
+            id: 'bcb1f0a7-6ac5-49c1-adeb-3dc8fa4e6159',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charmander remove
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Grovyle remove
+            id: '9a2ff038-9d5f-4c32-825a-7487003bcbfa',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Cubchoo remove
+            id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pansear remove
+            id: 'c4ecec83-9656-4194-8c47-5a5b00c10628',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darumaka remove
+            id: '1bbbb3da-d90e-4cbe-83f1-807358a6d35c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Venipede remove
+            id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dragonair remove
+            id: '64c4d808-c5e9-4227-b9cc-351777fcb591',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Riolu remove
+            id: '3063a957-dd1c-4941-8b37-d0984899515b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Empoleon remove
+            id: '2097e1f6-3330-4663-8a56-fef5995b075c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Prinplup remove
+            id: 'a05f33d0-472a-4db2-b6ff-a683c52101a5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bisharp remove
+            id: '699b6e0f-4d02-41ff-a2a9-0f562153861e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Haxorus remove
+            id: '6eda7ef3-3837-43b2-b2f6-8972aed2ec5a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Fraxure remove
+            id: '82429918-0b14-4ff8-ab8c-b7e34cf1d8d1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -565,13 +15269,214 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Klink remove
+            id: '4427bad2-356f-49ea-ade9-9c20ebd9a17b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golisopod remove
+            id: 'fa1b3931-846f-458b-9007-7063147c0c49',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Guzzlord remove
+            id: '194e85ae-e35b-4a8e-bf98-6996bc3d08e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Bounsweet remove
+            id: '07011066-6ca4-49cf-b3b1-aa3866480ef7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Necrozma remove
+            id: '037ae34f-ac34-4619-a37f-8b6e1adb08ae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Nickit remove
+            id: '41d13d7c-7eec-4569-85a9-3625ae72f5b5',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -617,13 +15522,744 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
         data: { id: '1e665730-88cd-4ca3-b03c-961c3a71e749', type: 'player' }
       },
       validPokemon: [
+
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
             type: 'pokemon'
           }
         }
-      ],
+      ,
+      
+      
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Quagsire remove
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dunsparce remove
+            id: '41115700-66dd-40bf-a5bf-a8b1949b537b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swablu remove
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shuckle remove
+            id: 'a9056e67-acfe-4264-9f78-06098b5e10dd',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Baltoy remove
+            id: 'aa88be52-a660-4253-ba00-dd6a84e4f73c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Seedot remove
+            id: '791964e7-c59a-4cfe-8f13-caf2c6be8b50',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Duskull remove
+            id: 'c374583a-36a8-4325-bf6f-74edbb419845',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lunatone remove
+            id: 'bf708485-a15c-4b56-9c9a-e93731114db0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Shellder remove
+            id: '2b76c5cb-cf54-438f-be01-ba2dc3a283d9',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rapidash remove
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Solrock remove
+            id: 'd71dc002-63ff-4fb6-ad1d-527f48c929d0',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        }
+      ,
+      
+      
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        }],
       year: { data: { id: '2021', type: 'year' } }
     }
   }
@@ -642,14 +16278,7 @@ export const competitionsData2021: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2021', type: 'year' } }
     }
   }

--- a/src/data/competitions/2022.data.ts
+++ b/src/data/competitions/2022.data.ts
@@ -19,7 +19,834 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Fearow remove
+            id: '2c7aaaeb-3f85-4c13-a2af-b0bb988fc102',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rapidash remove
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dodrio remove
+            id: '06e758bb-f708-4da9-8fec-2bad7a6b5203',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Starmie remove
+            id: '1f81cf39-3ecb-48ad-8646-da59e0f58988',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mewtwo remove
+            id: '9b9f6495-823d-4fcd-9177-c062f56b04de',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mew remove
+            id: 'eab1ccc3-376c-40e5-8821-7105115be935',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jumpluff remove
+            id: 'faddd5f7-0e8c-41fb-9771-2f15fc571bba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raikou remove
+            id: 'd35f25f0-1bd7-4e77-98ea-79b6058568e9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lugia remove
+            id: 'b3531d14-4ec5-4be1-b67d-ff1e5cb83511',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Linoone remove
+            id: '4f4b586f-7e77-4f68-b8bb-b3b623d90ff9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swellow remove
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slaking remove
+            id: '8f4452fb-da3a-423e-a0c4-64bed59f5173',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Manectric remove
+            id: '3e6d63f4-d3bf-4a3c-838b-72d1df53ec0a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Latias remove
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jirachi remove
+            id: 'd81fc796-f8c1-4919-a286-d0d7ceafa0f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Deoxys remove
+            id: '3f3c455d-707a-4212-a5d1-c0e743bbd970',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Infernape remove
+            id: '13c65177-38fd-4987-822f-f76671a94e5a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Staraptor remove
+            id: 'a57ba1c4-7bb7-44cb-89ed-5d6877bee767',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ambipom remove
+            id: '0c43aed8-0b5b-4052-9435-713e64a279ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mismagius remove
+            id: '44f1c66e-20ec-472b-bb43-daf348daa9bf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arceus remove
+            id: 'b35607d9-2dce-4ee6-a203-b5c57641297c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Liepard remove
+            id: 'a1fd01be-9555-4bf6-a231-68bd6f50250b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swoobat remove
+            id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scolipede remove
+            id: 'a2a8a168-8231-4b7a-a32c-26fbd07587a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Archeops remove
+            id: 'bdbbbc65-62c3-4a70-9f4d-ede5e85f4ba4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cinccino remove
+            id: 'ac6cbcb8-e173-4e6c-8dd7-7868eb5b7c1d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cryogonal remove
+            id: 'e798e439-2d71-4e85-8c9b-1c1e99fe331d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mienshao remove
+            id: '2fb38bad-ac28-4f28-bab6-10b296873c8c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cobalion remove
+            id: 'a4a4529d-cb64-4e76-876f-5c910ba16989',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Keldeo remove
+            id: 'eb582cd0-2c6a-404b-8c03-07825bdb31c1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Meowstic remove
+            id: 'f2d900c2-8d10-4709-b523-cd7c10eb32d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heliolisk remove
+            id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zygarde remove
+            id: '4308a44c-1711-4e94-9aca-8e1a97f9f0b3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Comfey remove
+            id: 'aeb2a45e-fe56-4891-94df-960a3f257bd9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nihilego remove
+            id: '069b5315-2193-45b1-b5b7-94964232e3ce',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Marshadow remove
+            id: '6d76251d-04a5-40bc-9f62-5e95790703e7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Naganadel remove
+            id: '9d07d1ca-ac0c-4356-be4d-b692f136101e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Blacephalon remove
+            id: '2009f303-b813-474c-be27-a7469dcc522d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zeraora remove
+            id: '4b161dfb-98fe-4135-a1a2-3e225ad6593e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cinderace remove
+            id: 'f88e70fc-6101-49cd-a6b3-570bc4bf4342',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Inteleon remove
+            id: '0d817f85-f24c-483a-babf-600f8c024830',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Boltund remove
+            id: '45ac1a90-8a7e-44dd-8d2c-d8c5e30baaa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Barraskewda remove
+            id: 'b5638d8e-d19b-470c-b04e-0bca946de8a9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eiscue remove
+            id: '8f2a29b1-fefc-46f4-95ef-d9ecca5ff167',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drakloak remove
+            id: '6041715b-b9ff-4fbe-99c9-c6cab724effe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dragapult remove
+            id: '5597de67-0458-4eee-a571-3ed56febf4ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zacian remove
+            id: 'be49bf03-629c-4b4e-8ea9-e842af3329d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zamazenta remove
+            id: 'efbf2e5b-7941-487f-bd5d-8697988091fa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zarude remove
+            id: '0636fc26-cf46-4850-b481-711546e3d76f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spectrier remove
+            id: '4a7ac3b2-b34e-475f-98f0-18330af11687',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Calyrex remove
+            id: 'c99809ef-a138-4554-9532-6e0367b9128e',
             type: 'pokemon'
           }
         }
@@ -45,7 +872,1058 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Quilava remove
+            id: '0b9f8351-8d36-40e7-b123-f7583a6d271b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Popplio remove
+            id: '631a2c39-6231-45b3-807c-cd365c5bf995',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Brionne remove
+            id: 'dd947474-1775-416c-829a-197aef7b2f48',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Primarina remove
+            id: 'f82418ad-7080-4dc7-9036-2ec54cf50a6f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Relicanth remove
+            id: 'd6a1a76f-7eb4-4b14-80d6-8978d4080889',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clauncher remove
+            id: '5ec37ba4-83a7-4d40-bbf6-212d324686fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clawitzer remove
+            id: '6d8d87dd-7d20-443f-8be8-c30cd56c7e36',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poliwhirl remove
+            id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poliwrath remove
+            id: '81a3f4aa-b5be-4e27-89c8-3cefba70c5eb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninetales (Alolan) remove
+            id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Frosmoth remove
+            id: 'bc130ef1-f6fb-4093-9ebc-32431a57a09d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lapras remove
+            id: 'eaf401e1-ddb3-4917-bda3-f7a6b3046ba3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lycanroc remove
+            id: '46b781dd-5818-48df-ad45-dad290fadcc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dwebble remove
+            id: '30741c01-f409-4f02-93e7-e8356a8565c6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cranidos remove
+            id: 'd1490924-fe95-4c28-81be-c2e98298b69c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rampardos remove
+            id: 'b591dc28-40ad-48fd-853f-6862161b6a8d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Krokorok remove
+            id: 'e15f96df-a8a2-4b2d-953c-ef1cf3037220',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skrelp remove
+            id: '0b4905b3-bd2f-4714-bbdb-c88474d52b6f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dragalge remove
+            id: 'ea3941f8-2fda-443e-b80c-d7ddd8e00d12',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salandit remove
+            id: '1cd76c6a-7326-44ea-ab7f-5f366c03712d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roserade remove
+            id: '67f1990d-2c87-4efa-815f-539a576ceca1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Deerling remove
+            id: 'de2252f6-ba8f-40f9-98de-c4b725e7bffe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sawsbuck remove
+            id: '147eebec-bc96-4ee9-b4dd-3f0a3fc93d91',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Applin remove
+            id: '568746c3-51f1-4050-bbe7-66829f09e3df',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flapple remove
+            id: 'a4ec17ef-d300-4cf1-95f3-a0d060f790ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Appletun remove
+            id: '7e8e5d61-57e7-4378-a66d-e84f3f21f0ee',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Litwick remove
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lampent remove
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Houndour remove
+            id: 'f050feaa-7a93-499a-b7fc-619d579252a0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Houndoom remove
+            id: '843f6c5b-322d-43da-8faa-845a8af16009',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nickit remove
+            id: '41d13d7c-7eec-4569-85a9-3625ae72f5b5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Thievul remove
+            id: '333868c1-c484-46f9-8a4c-f52e4ce9f60c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Honedge remove
+            id: '0633d25c-8f26-4049-8403-407ff49b7a1d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Doublade remove
+            id: '3c48f457-e591-4fc7-9df1-57dfc5f94589',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gallade remove
+            id: '34f1dd7b-5470-4203-9abe-93ce7bc49442',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beldum remove
+            id: 'efe1c7a0-9333-40cf-8017-6a04a9a4187d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metang remove
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skarmory remove
+            id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magnezone remove
+            id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cufant remove
+            id: 'c1986420-412e-415d-961c-b57bb6f3245c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Copperajah remove
+            id: '5ae94a7c-f5fe-41e4-b89e-68cdb534f313',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hawlucha remove
+            id: 'bf992efa-c8dc-4eee-a2bd-5ba86e2d7feb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sirfetch'd remove
+            id: '14a0090a-50cd-4934-8fc5-228775adf3f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clobbopus remove
+            id: '57535eca-9be6-409c-94b3-7f781a4e2216',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grapploct remove
+            id: 'ac67bc65-c761-4cef-87b2-1b4199de77fa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Impidimp remove
+            id: '54deb667-a45a-4afc-898e-392d98b33e33',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Morgrem remove
+            id: '1cb1ac9a-1239-4467-9697-cea9fd1ddde2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grimmsnarl remove
+            id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togekiss remove
+            id: '8f95aee6-776a-4df8-9c67-86ec9c7345d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mawile remove
+            id: '963e95c9-a4b8-45a7-bdc3-4c4e56e6b307',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wooloo remove
+            id: '82296f48-2914-4e67-8538-8b9c68158cd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dubwool remove
+            id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stoutland remove
+            id: 'fbe602de-b2dd-480a-90d0-8f86c810db42',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Furfrou remove
+            id: '97ac9b43-d8ce-4dfe-a7de-928e87bd9f0a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sylveon remove
+            id: '461b6f2a-7e72-4476-9593-2375a3b24f4c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electivire remove
+            id: 'afdc72cf-5d26-43dc-9e70-f54d68023f80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mareep remove
+            id: '2d3f45a9-8f6b-4540-9171-037c8a0dac74',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flaaffy remove
+            id: '0bc1956d-f21f-4b11-ba29-ffcf7c3a2cad',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ampharos remove
+            id: '5e94edae-8268-4a80-bf92-3d07ce8150aa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cramorant remove
+            id: '772314d7-ca25-457c-9f30-531f979b521c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Fletchinder remove
+            id: 'dea6547f-a748-4f0d-bdce-28db80bca139',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Deino remove
+            id: 'd5ba5779-ab90-42e5-b841-200d9bf4cfba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zweilous remove
+            id: 'f5374f2f-62e7-4881-9cbc-a12c18c37050',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jangmo-o remove
+            id: '3ef6183e-c053-4b59-9be4-194a784c21a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hakamo-o remove
+            id: '00670562-8c57-4b22-b4dd-56cd18427c55',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kommo-o remove
+            id: 'bb7e62c5-e6c8-4214-ab20-744381c7fea8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aurorus remove
+            id: '6393dbe9-0cb1-4af4-a682-b6213b72861a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cutiefly remove
+            id: 'f590d249-312f-409a-b606-bbadf1228aa2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Larvitar remove
+            id: '14338c64-e7d5-4cfb-8719-bb5f4b1ebace',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pupitar remove
+            id: '0a37c422-1161-4ca8-b79d-cb7fad1b9234',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spinda remove
+            id: '2b09d741-e957-4185-baa4-c0e922f26380',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pheromosa remove
+            id: '5999866a-9753-4d47-a267-01751c3617c7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Virizion remove
+            id: '59b144bf-12e8-4b48-8824-c38f4f4cb99b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Calyrex remove
+            id: 'c99809ef-a138-4554-9532-6e0367b9128e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Farfetch’d (Galarian) remove
+            id: 'b6af61b9-ea70-4cd5-9c39-b901a94ced0c',
             type: 'pokemon'
           }
         }
@@ -71,7 +1949,1695 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dartrix remove
+            id: '05f0c8f1-d3bc-41ba-9e5d-ca1a03dbb3c0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Quilava remove
+            id: '0b9f8351-8d36-40e7-b123-f7583a6d271b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Oshawott remove
+            id: '1bf76a95-4044-4689-bc8b-d587c347126a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dewott remove
+            id: '040027cd-6a60-40cd-8f2b-17775d5e6a1a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bibarel remove
+            id: '35c540eb-cb16-4d8e-b4d3-2a3f474aae6a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Staravia remove
+            id: 'a085af72-5226-4aff-a2f7-5b5e11d85d31',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Staraptor remove
+            id: 'a57ba1c4-7bb7-44cb-89ed-5d6877bee767',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shinx remove
+            id: '8faec058-51ec-472d-80f5-53b37449795c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Luxio remove
+            id: 'c497bf5b-aff0-477d-984d-42172d973126',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Luxray remove
+            id: '0224b47f-0a36-4d35-9b15-dffc7d4ac397',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wurmple remove
+            id: 'c36f780b-5769-407b-9600-921d57ace904',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Silcoon remove
+            id: '93fe0833-dd33-4735-a8d8-92eb1b63df39',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cascoon remove
+            id: '0ae55560-a0fa-4c15-a699-525b09ad844f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dustox remove
+            id: '8b752fd0-5f8a-472c-8aa0-b99ca570cd70',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ponyta remove
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rapidash remove
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vaporeon remove
+            id: 'd008fb97-c343-4f85-86ce-7bd7dcf27094',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jolteon remove
+            id: '068990b5-beda-45b7-a11c-b9b121f8f2a5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Espeon remove
+            id: 'f6723a6c-bd0f-4c8e-8a3f-c64824e9a9b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Umbreon remove
+            id: '23fe166f-e2f6-4e22-8682-ba01a4ffcac5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sylveon remove
+            id: '461b6f2a-7e72-4476-9593-2375a3b24f4c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drifloon remove
+            id: '279b1e2e-4145-4829-9f39-d5e8d2e25a31',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drifblim remove
+            id: '38e9e1c0-2a92-4ab9-ab1c-aabfb75f8fed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kricketune remove
+            id: '86bc78c6-4450-41c9-b070-87ccadd9b1c2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Buizel remove
+            id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Floatzel remove
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wormadam remove
+            id: '14cd8b1e-b0d2-4539-b415-958863c11348',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mothim remove
+            id: 'd7ac1ca8-8090-4f7b-a598-afc6f0849443',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golem remove
+            id: '09a002b1-b0be-4ca3-82bc-cd26c1bf166f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stantler remove
+            id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wyrdeer remove
+            id: '7cc18c1e-e04d-41fc-8321-f5097db20580',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pichu remove
+            id: '8664bc55-da05-4069-9e68-7512901224ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Abra remove
+            id: 'c6423ee0-03a5-4202-ab14-eea098c00593',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kadabra remove
+            id: '295363bb-8b96-40d8-b940-dfe4131726f9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Alakazam remove
+            id: '0b0fdead-d8cb-4967-a4b6-c12f6f3ad2f8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chimchar remove
+            id: '27c6fafd-8273-4951-a5e1-8c7727a16333',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Monferno remove
+            id: 'd7efade3-58f8-4789-b7b1-aeb4f070156b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Infernape remove
+            id: '13c65177-38fd-4987-822f-f76671a94e5a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Buneary remove
+            id: 'a269af69-71bb-472d-87b7-195e46062ba3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lopunny remove
+            id: '0eb5cac7-b4ca-4c04-a832-e3176a42eee4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cherubi remove
+            id: '19618a6b-e347-49ad-a5d5-08582c8bf817',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golduck remove
+            id: '5b091d78-f36d-4a2a-8069-d9bfffd0ee92',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Combee remove
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vespiquen remove
+            id: '37421e2b-86d5-4cfa-9ce3-d5bf07dfea54',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kleavor remove
+            id: '0133e319-db94-4eff-a3ec-2cedea69a1d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mime Jr. remove
+            id: '758c86f7-e08f-4aa7-ac55-a345669ad53a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mr. Mime remove
+            id: 'e2874a24-5160-4fc5-bb76-07d0f3de0bd5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ambipom remove
+            id: '0c43aed8-0b5b-4052-9435-713e64a279ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shellos remove
+            id: '0091eadb-706c-40d1-ba11-5c95b383b46b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Qwilfish remove
+            id: 'd9865e99-9f5c-4598-b66e-bc0709208944',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Overqwil remove
+            id: '139fef89-4f9f-4313-8896-e8890c09c937',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Happiny remove
+            id: '138e873d-db9b-4f2b-bd9a-59757b9282e8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roserade remove
+            id: '67f1990d-2c87-4efa-815f-539a576ceca1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ralts remove
+            id: '3fd72417-b6f1-4130-abbb-55a0803e2b33',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kirlia remove
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gallade remove
+            id: '34f1dd7b-5470-4203-9abe-93ce7bc49442',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Yanmega remove
+            id: 'aeeb2928-d3c8-4995-ae1b-be5c4d4f5b9a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hippowdon remove
+            id: '490929b2-9162-4bef-ad11-e84a8b3ba91c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stunky remove
+            id: 'ba3459b2-c4bc-48a7-99fc-ebe206b07017',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skuntank remove
+            id: '7fc75ee8-810f-4cee-830f-e24f1c2b3ba4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Teddiursa remove
+            id: '7d45091a-aba7-4f9e-9109-d5b4ec12229f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ursaring remove
+            id: 'a1621c75-95db-477d-9f4e-8c01a287709e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ursaluna remove
+            id: 'd13169de-e586-48d3-abec-d35a59a9328a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Goomy remove
+            id: '56c95763-648b-4526-a580-e5f4487c0665',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Goodra remove
+            id: '36ed9371-57f3-4aef-bd23-47230a25569b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Steelix remove
+            id: '09476a48-454e-4a36-88a8-192abacbcf7c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rhyperior remove
+            id: '4a490992-44a5-40ee-9cd0-7505b37af645',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bonsly remove
+            id: '507c9298-b5c6-4314-8f49-10dc43e7ba64',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lickitung remove
+            id: 'cfe0414b-cb76-43dc-ad2b-aac363edc62c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lickilicky remove
+            id: '0cb38d3b-4149-44fc-8e14-a17f8906ae81',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togepi remove
+            id: '04f14ad6-a318-420b-8191-c8133e21b5b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togekiss remove
+            id: '8f95aee6-776a-4df8-9c67-86ec9c7345d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Turtwig remove
+            id: '744a3eb6-8697-4e2d-a813-27ef655491c0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grotle remove
+            id: '259a773b-f770-47ec-9459-59bd20cc2711',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Torterra remove
+            id: '16089a5e-4004-4c13-96ad-64197b0b35d6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Porygon remove
+            id: '32db34f7-0c11-401c-8504-d399aa98e376',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Porygon2 remove
+            id: '7fa95f76-105b-45bf-9d9a-00f20329bee3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Murkrow remove
+            id: 'b611b2fa-3178-4735-9891-52d9571058bf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Honchkrow remove
+            id: '98477623-c2fd-46c2-9fa8-50a2649333f5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Unown remove
+            id: 'c47787a9-7b74-4f4b-93e9-e0836ef7cd28',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sealeo remove
+            id: '414129cc-0302-4d8d-86a0-53dd80451bb2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Walrein remove
+            id: '0a3776f1-3b80-478a-aa9f-47c207c94378',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Remoraid remove
+            id: '1f9b78d2-1616-46a1-96d4-81d6bc3c9f3b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skorupi remove
+            id: '187c9d4c-0291-4e01-bca2-0ecab809dae9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Glameow remove
+            id: 'b0fff790-de0b-41fe-b0cd-05117c22b6f6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chatot remove
+            id: '1a0b6846-d45a-4fd2-98a7-7a3946743e7f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Duskull remove
+            id: 'c374583a-36a8-4325-bf6f-74edbb419845',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dusknoir remove
+            id: '52017eec-3563-4d7b-9845-d4f81a575d2f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Piplup remove
+            id: 'e975c325-8eca-4252-aa82-8433064775c9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Prinplup remove
+            id: 'a05f33d0-472a-4db2-b6ff-a683c52101a5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Empoleon remove
+            id: '2097e1f6-3330-4663-8a56-fef5995b075c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mantyke remove
+            id: '843db6b2-bde6-484e-b3fb-0e813d320062',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mantine remove
+            id: '90d58436-5903-4459-9e87-210b8b2d2750',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Basculegion remove
+            id: '5425c023-cd46-458a-90c3-efff7d263af7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vulpix remove
+            id: '27c9fadf-f8cd-4b42-857a-987113ebaec5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninetales remove
+            id: '2141da9e-875a-4851-8d2a-8c3a0fa938c3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tentacool remove
+            id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tentacruel remove
+            id: '13633ad8-e514-4b85-90d3-5ffa01093eec',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Finneon remove
+            id: 'dae80cde-8a92-4a23-b9fb-9b0218b34b51',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lumineon remove
+            id: '05986577-0d49-4e49-9556-4a7c1d681794',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magby remove
+            id: '745e1717-530f-423f-9d98-96457a1a218b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magmar remove
+            id: '9356e54c-96fb-4b1e-bd29-eb772f8056ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magmortar remove
+            id: '0ca0d2f8-5f6e-443a-aed6-2b6f4902b6ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magnezone remove
+            id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bronzor remove
+            id: '6ec12acc-3259-41f2-b18c-0c7df67af075',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electabuzz remove
+            id: '38bb56ef-f998-44fd-9382-0b2ccc42f18e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electivire remove
+            id: 'afdc72cf-5d26-43dc-9e70-f54d68023f80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gligar remove
+            id: '8d04330d-3e11-4191-ab8d-9a5137f8e659',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gliscor remove
+            id: 'ac359f44-f9a8-427f-922f-b980f3dc755d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gible remove
+            id: '64abb33e-69da-4e81-8468-ed2348ca2369',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Probopass remove
+            id: 'dd4e7387-f636-47c8-9eee-062f1d8b4eeb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chimecho remove
+            id: '1b2d34e5-43cb-4b4e-ab6d-a876c8b038f1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mismagius remove
+            id: '44f1c66e-20ec-472b-bb43-daf348daa9bf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cleffa remove
+            id: 'c40c9353-5437-43c0-ba7c-07abc32b7074',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clefable remove
+            id: '41e87cd7-34c6-4f5c-b971-b83e93203b50',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sneasel remove
+            id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sneasler remove
+            id: 'fe70d5fb-ba60-4278-aa9e-a5d4b89eaa9c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weavile remove
+            id: '5e8d3be1-b084-4217-8456-0fa6d74ba2ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Glalie remove
+            id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Froslass remove
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cranidos remove
+            id: 'd1490924-fe95-4c28-81be-c2e98298b69c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rampardos remove
+            id: 'b591dc28-40ad-48fd-853f-6862161b6a8d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shieldon remove
+            id: 'c5d23098-25f7-4494-a38c-33fccab7c90b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bastiodon remove
+            id: '754ae45a-c41b-4004-9cc9-f93638145b79',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bergmite remove
+            id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Avalugg remove
+            id: '06e87530-bdd5-41cd-8a70-197d8f70035a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snover remove
+            id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Abomasnow remove
+            id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rufflet remove
+            id: '01346e6f-94e0-41a3-8248-3e6b7f784a04',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Braviary remove
+            id: '9b2be3c5-ab6b-4e00-bfaa-6618820b7bde',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Riolu remove
+            id: '3063a957-dd1c-4941-8b37-d0984899515b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lucario remove
+            id: '4de46c79-b0e0-4bc0-a686-f877f21fe6df',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Uxie remove
+            id: 'da1d58bf-7628-4951-bea4-afff5003bf2f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mesprit remove
+            id: '6a34bf43-21f4-4f6b-84f1-4aec0940a2e5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Azelf remove
+            id: '6bdec89a-de2c-455e-aefd-a84ce5db4947',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Enamorus remove
+            id: '31ba1019-2571-4d23-ba57-d5b0cba90fbd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Giratina remove
+            id: '2f33cc14-e04c-4ffb-b36d-67f1d3aea1e4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arceus remove
+            id: 'b35607d9-2dce-4ee6-a203-b5c57641297c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Phione remove
+            id: '3c1ff9c9-4164-48b4-9f45-f87abdf0f3aa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Darkrai remove
+            id: '8a625456-e3af-4a2e-b0ce-0baea8bd4fcb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Porygon-Z remove
+            id: '55eeff70-26ed-49ec-bcbc-06445a241da7',
             type: 'pokemon'
           }
         }
@@ -201,7 +3767,337 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Zacian remove
+            id: 'be49bf03-629c-4b4e-8ea9-e842af3329d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grimmsnarl remove
+            id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regieleki remove
+            id: '1d12f572-4220-40c6-a5ce-fd19e9eeaa84',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rillaboom remove
+            id: '81f20cbc-e206-46cb-8114-65e6a5637fbb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Calyrex remove
+            id: 'c99809ef-a138-4554-9532-6e0367b9128e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Indeedee remove
+            id: '60658712-b6ba-4bdd-bae6-d68cb9baf6fa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Yveltal remove
+            id: '0d51dea2-f5b1-43ef-991c-75475d1e1af8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Porygon2 remove
+            id: '7fa95f76-105b-45bf-9d9a-00f20329bee3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Blastoise remove
+            id: 'ed6e9810-f1a6-4a74-a90b-e353f56308a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ferrothorn remove
+            id: '0b80d2e6-a425-47b7-baba-b7109da9e17b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Urshifu remove
+            id: '5da303c7-e2b2-47ee-be17-51812f0609d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Xerneas remove
+            id: '394ee517-c117-4570-84d1-b539a4c81e2d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Solgaleo remove
+            id: 'fd0a54b9-f672-4ade-a56a-f54281394170',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dusclops remove
+            id: '3bd8dcbc-9969-4ce1-830c-bfa707d2d9e1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kingdra remove
+            id: 'e99aa0f1-460c-499f-9c39-0279a7490881',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weezing remove
+            id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Entei remove
+            id: 'ecd419f7-0259-4d1d-8bca-2887ca913ffd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lunala remove
+            id: '3d2bb9be-448a-4017-b29c-e5092cf40d92',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kyurem remove
+            id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sableye remove
+            id: '660c3b60-e28f-4639-be49-39889334c531',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tapu Lele remove
+            id: 'c6aef3ca-988c-4112-b218-7a4a7befbe5a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gothitelle remove
+            id: '93fac96d-70a5-46a4-b450-0a0491b5130c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Seismitoad remove
+            id: 'd9cd1dea-3557-42e0-b7e4-e7856ed492ec',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ho-oh remove
+            id: 'e5a75391-c628-4807-939f-0bc60c5a001c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eternatus remove
+            id: '12b1c392-52d7-4c6c-b7ba-ff6a6e03b9f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regigigas remove
+            id: '527e4a6c-7e76-4e5b-b990-a63bed6f0d7c',
             type: 'pokemon'
           }
         }
@@ -253,7 +4149,379 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Dracovish remove
+            id: 'aa85175c-0613-4d07-a465-7b068c3f82ad',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Charizard remove
+            id: '1f5d9dc9-a7d4-42f9-8253-c7a7e0a8b1ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Squirtle remove
+            id: '75c0ff1b-c295-427c-87fc-e3d95d9baa2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Toxtricity remove
+            id: '0a8f7946-f52a-4530-ac61-edece7ffec32',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Porygon2 remove
+            id: '7fa95f76-105b-45bf-9d9a-00f20329bee3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Meowth remove
+            id: '9309bac4-a765-4e49-ae57-2dcacd543f20',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Corsola (Galarian) remove
+            id: '171176ae-9298-4fa3-9e93-5d208ca61a72',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ponyta (Galarian) remove
+            id: '6e1abaf6-8b92-4354-a9f8-1d2f0f0f5b71',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mr. Mime (Galarian) remove
+            id: '98edd436-162e-4e9d-ab09-2657ed54052d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Oranguru remove
+            id: '65cb7a97-ff74-4733-932b-a0e4ac7cdfdf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aerodactyl remove
+            id: '1e2cfc21-db12-4765-9754-e87f7cb3f068',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Decidueye remove
+            id: '675d9a60-4172-41d7-bc8f-46292bbe62dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Primarina remove
+            id: 'f82418ad-7080-4dc7-9036-2ec54cf50a6f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arcanine remove
+            id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Greninja remove
+            id: '4a62e4ad-cfaf-414e-9a45-4d50502aa57b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dragonite remove
+            id: '19f943c0-200f-4b6b-aff3-e2df242bfa99',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zoroark remove
+            id: '25500aa7-0741-4de8-b1ef-296347e8e391',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Amaura remove
+            id: 'abdf6272-a4b8-4395-8493-20745dfb1830',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tyrunt remove
+            id: 'f28eb08d-4823-4019-bb92-3a0dde9e0e98',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Feraligatr remove
+            id: '3a6040fd-7480-41f2-a7ad-f03d18f9612a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Typhlosion remove
+            id: '44f58ac0-a2d6-4fe1-b1a2-126011c0510e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Meganium remove
+            id: 'fff24eb1-a56d-4730-8160-182ac19f701f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Samurott remove
+            id: '700a899a-f2af-4066-aff2-23603db8c2f9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Emboar remove
+            id: '392370ea-20a7-4516-86e4-e6c317e99b60',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Serperior remove
+            id: '1531f036-ccb0-4647-8161-bdf4da145c7d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beldum remove
+            id: 'efe1c7a0-9333-40cf-8017-6a04a9a4187d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pumpkaboo remove
+            id: '92f1c2b5-7a27-41e3-98f5-ae7f8ca98d2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aegislash remove
+            id: 'db2fdc0d-10eb-4064-b148-0771a76396ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vivillon remove
+            id: 'f1c992c4-d94d-42f4-add7-d16864cdea0f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scizor remove
+            id: '0874e9e6-f4a0-4114-83c1-fabc0dfa665c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Torchic remove
+            id: 'da4d8b9a-edbc-4521-a783-ce83551a912e',
             type: 'pokemon'
           }
         }
@@ -279,7 +4547,442 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Persian remove
+            id: '1f63e1d1-d6ca-49ba-a3fa-bc54678b99bd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Seaking remove
+            id: '3992362d-ae97-4949-8efc-c4e53483718b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flareon remove
+            id: '832750ec-e083-4096-9dc8-c38121d64a68',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Articuno remove
+            id: '2f8e8786-b56c-4df7-8eea-5d081803dbdc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zapdos remove
+            id: '67108388-ed6d-4ade-b8c3-fcb618fa32b0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pichu remove
+            id: '8664bc55-da05-4069-9e68-7512901224ac',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Igglybuff remove
+            id: 'acc70f99-f706-45c5-8a58-989969a970a4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togetic remove
+            id: 'f56b3b40-1d5c-4115-90e2-c438d4b89c3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flaaffy remove
+            id: '0bc1956d-f21f-4b11-ba29-ffcf7c3a2cad',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Phanpy remove
+            id: '5a1de7c3-bcb3-4eb9-8365-e45e404bb023',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Smoochum remove
+            id: 'fe4377b2-be91-4308-9401-9d337624ad45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Elekid remove
+            id: 'b974027f-18ef-4768-9dd0-21fe1037257f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Blissey remove
+            id: 'a47d543b-3464-4b03-9eee-c5d73a94fd14',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skitty remove
+            id: '89d387dd-40b4-4323-9511-05bf19ec2c6c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regice remove
+            id: 'bc9d6986-f768-4988-a37c-f7437709c9d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Starly remove
+            id: '782c12a1-fdf5-45a2-81a5-88f8a508f67c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cherrim remove
+            id: 'bcc687ee-cd7a-4762-a5de-ed16ab86b246',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hippopotas remove
+            id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drapion remove
+            id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Leafeon remove
+            id: '708bb168-1e4e-43f6-a500-9408ca4045fb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Glaceon remove
+            id: 'd233e99a-725f-410a-9cf1-a90835321d20',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palkia remove
+            id: '2cba6507-318a-4559-ab8d-b28f19303ee6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Manaphy remove
+            id: '9953c608-f870-43e9-8db2-f1ab1d27e65c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lillipup remove
+            id: 'c7cf3c2e-8184-44d1-be99-62b89f498865',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Simisage remove
+            id: '9edae28b-42df-45ee-b38e-5197bcbb8062',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Simisear remove
+            id: '556e90c1-1fe0-404d-81cf-108d7ed193a5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidove remove
+            id: '20c0062a-e0b2-4bf5-ae0c-ac4b142c1c54',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Basculin remove
+            id: '7411e93e-127f-42ee-99fe-d44f31e7b60a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dwebble remove
+            id: '30741c01-f409-4f02-93e7-e8356a8565c6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Carracosta remove
+            id: '13f93610-2645-4179-aacc-f4b19858f606',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gothita remove
+            id: '571e8806-a993-449a-9d8e-11ce979ca911',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vanilluxe remove
+            id: 'aeebded8-2b5f-4b4a-8afb-1d0e780d6f29',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sawsbuck remove
+            id: '147eebec-bc96-4ee9-b4dd-3f0a3fc93d91',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tynamo remove
+            id: '7e20ee70-a9eb-4d71-87ff-796131965f57',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beartic remove
+            id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bouffalant remove
+            id: '423f263c-aed0-4b24-be99-11de2ac70290',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zekrom remove
+            id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flabébé remove
+            id: 'd750fb34-d294-4862-9c8d-8d04a72570a1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Minior remove
+            id: 'e78e09d4-43d3-44bb-9c87-d2ff0e469e2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Yamper remove
+            id: 'e6a04cee-d60c-4e0e-9306-eafc52020b62',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snom remove
+            id: '1a26f50f-4b43-4e37-81cf-c10d3f0c0126',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Farfetch’d (Galarian) remove
+            id: 'b6af61b9-ea70-4cd5-9c39-b901a94ced0c',
             type: 'pokemon'
           }
         }
@@ -305,7 +5008,624 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venomoth remove
+            id: '9d8e9855-9000-41f9-a4c1-abe4d41fe8c8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pinsir remove
+            id: 'fd80cbeb-5aa9-4176-8252-fc90c499626d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venonat remove
+            id: 'cac2064e-9c81-4536-80d7-9c39af52113e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scyther remove
+            id: 'f6e13a94-bcb0-4747-8c0e-cf45331cff80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tentacool remove
+            id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dewgong remove
+            id: 'abc737b7-7b49-41d8-881d-7bb7dcfa3f8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spearow remove
+            id: 'c60b77ae-8db9-4caf-8ec7-bfa52862f6cd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rattata remove
+            id: 'a522c362-5189-4346-8947-4598b390affa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poliwag remove
+            id: 'f28cf959-bd7f-481d-ba9b-6fb475c4233b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ekans remove
+            id: 'c4908eda-0b33-4bbb-9501-e545a408c38c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Geodude remove
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grookey remove
+            id: '3ca532e9-3cb5-44f4-b157-08ce4b3bf578',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raticate remove
+            id: 'dbaea5f9-d1d4-434b-9437-42753792b3d2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Graveler remove
+            id: '85a703ab-af6c-484a-9260-3300916af26d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cloyster remove
+            id: 'be37c657-0018-4afc-9bab-dde828130189',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stantler remove
+            id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Misdreavus remove
+            id: 'c01cf54a-6bcd-43dc-ab72-2f215e20a269',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ariados remove
+            id: '291f1a5f-0754-42d4-a21c-286883f9f642',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pineco remove
+            id: 'da602af9-4a1d-40bf-9042-f943f7241a9d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chinchou remove
+            id: '4b854817-7f27-4ee5-9dd0-b04a34b8256e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Suicune remove
+            id: '9c1bd503-f635-45e8-9cb2-b88c43a0b80c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drowzee remove
+            id: 'e3d7e9a1-85cf-471c-86ec-18bf93ecefd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Murkrow remove
+            id: 'b611b2fa-3178-4735-9891-52d9571058bf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Taillow remove
+            id: '3bc05b77-1328-4dff-849d-214826190c49',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wurmple remove
+            id: 'c36f780b-5769-407b-9600-921d57ace904',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flygon remove
+            id: 'cfd51894-9021-49d2-85a0-48436a5030bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Absol remove
+            id: 'b25d8f50-aa81-42bb-8274-81b65833fa08',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Altaria remove
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mantyke remove
+            id: '843db6b2-bde6-484e-b3fb-0e813d320062',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Goldeen remove
+            id: 'ae0de176-5c64-4406-b3ba-1b2ef55c6150',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Darmanitan remove
+            id: '7b16a8cc-41ec-41d5-b04e-69e77765777e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golurk remove
+            id: '47d44ab9-e67c-4ae0-a975-2396c9ec8793',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pansear remove
+            id: 'c4ecec83-9656-4194-8c47-5a5b00c10628',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Panpour remove
+            id: 'dfd21c51-0564-4745-b017-61b1733962b9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Durant remove
+            id: 'ed4bac1b-ff50-4e13-90c2-7173c9f6493a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roggenrola remove
+            id: 'cc0af826-8ee8-426a-bd0b-45bc81f50a1c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ferrothorn remove
+            id: '0b80d2e6-a425-47b7-baba-b7109da9e17b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flabébé remove
+            id: 'd750fb34-d294-4862-9c8d-8d04a72570a1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scatterbug remove
+            id: 'de189ff7-1bf7-45ae-a49d-92c28217d44e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Phantump remove
+            id: '4bd98ba2-8bc2-4336-b96a-f4565bc34cc6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Fletchling remove
+            id: '4cf0a1fb-d7f6-4a71-8d99-f711ab637626',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggutor (Alolan) remove
+            id: '4008313c-b38d-41c8-a8e1-7b9e5514ca73',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bruxish remove
+            id: 'd06db98e-bac0-4676-bf64-0cb0101ef847',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Passimian remove
+            id: '81d0f9f3-c739-4b44-acd5-f76b00152f1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scorbunny remove
+            id: '04182a98-03e1-4072-84c5-e3c84a6891dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skwovet remove
+            id: '2d6d959d-d951-464c-8a99-ebbd693ae643',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sobble remove
+            id: 'a829996d-61ac-4a55-beac-8197735e7687',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Boldore remove
+            id: '772d2854-7a6d-4625-a711-5d23aa419dbe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arctozolt remove
+            id: '45608793-1fd4-4596-8fa8-51d8ab0205d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stunfisk (Galarian) remove
+            id: '3c64e523-a068-49e0-9b62-4cb9c4400965',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Falinks remove
+            id: 'a47be34b-890b-4260-b54f-565162e3300d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Milcery remove
+            id: '487c56e5-9319-46a0-81bb-1666d9219e45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Corsola (Galarian) remove
+            id: '171176ae-9298-4fa3-9e93-5d208ca61a72',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gossifleur remove
+            id: '4b50a13b-39db-41f5-ba0f-9dc65a8c8011',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regieleki remove
+            id: '1d12f572-4220-40c6-a5ce-fd19e9eeaa84',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Krabby remove
+            id: '09c4d189-ee58-44c1-b8c0-9bd51d39dd60',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hoothoot remove
+            id: 'bad16e91-df23-422a-a31c-085f9ae09365',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
             type: 'pokemon'
           }
         }
@@ -331,7 +5651,169 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Diglett (Alolan) remove
+            id: 'b6d62454-b853-4731-a020-d810f536d7fa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Natu remove
+            id: '5cfdd898-80d0-4fa7-b728-30b28f871ca0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Azurill remove
+            id: '300ff49a-cc70-4e5d-ac0d-8c3556a69441',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chingling remove
+            id: '1c7d0854-dade-46b1-98e7-e28f5b2344bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shaymin remove
+            id: '8ec0d8ac-e8a0-410e-9476-78636256eb1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tynamo remove
+            id: '7e20ee70-a9eb-4d71-87ff-796131965f57',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Floette remove
+            id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spritzee remove
+            id: '9d449555-1595-4472-91db-6752abd6722f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Klefki remove
+            id: '6efa30ac-52ee-43e5-ba44-6de796148def',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wishiwashi remove
+            id: 'e23fab77-2715-434d-b146-4d9664479ffb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mimikyu remove
+            id: 'ce5f25ec-240c-43b4-b417-007aeaff5b4f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cosmog remove
+            id: 'e4afb300-c937-46bb-9780-f727f77c8f3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Meltan remove
+            id: '1b7f2d73-3a74-434a-9c15-b32d3e9229c4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rookidee remove
+            id: 'f52a7d08-b297-4564-89a7-a9548f2a00c3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Applin remove
+            id: '568746c3-51f1-4050-bbe7-66829f09e3df',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Polteageist remove
+            id: '8f964492-a6ad-4157-991c-abd964de54d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Milcery remove
+            id: '487c56e5-9319-46a0-81bb-1666d9219e45',
             type: 'pokemon'
           }
         }
@@ -357,7 +5839,1639 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Impidimp remove
+            id: '54deb667-a45a-4afc-898e-392d98b33e33',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venipede remove
+            id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Elgyem remove
+            id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Toedscool remove
+            id: '6b57b43b-60e3-44e8-b740-0635e8e899ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wiglett remove
+            id: 'b64a786c-16b2-49b4-a507-5debb67a8ae5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Brute Bonnet remove
+            id: '049b64b0-42a8-47b0-983b-a0bddbac6e03',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastly remove
+            id: 'c0a46fea-95bc-4747-bb39-7f1479ba7456',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Haunter remove
+            id: 'f63c9faf-ed25-468a-8808-f7a6e319cd04',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rowlet remove
+            id: 'b5e001d3-94f1-4b6f-b7b7-d7a9ebb20ee1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lechonk remove
+            id: '90a0c67a-ea66-4b05-a603-b1a625e21f64',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Frigibax remove
+            id: '9f8c7a79-1fcc-4c5c-95b5-a6e49d170c5b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arctibax remove
+            id: '3e686abb-7820-4b27-970b-f1101c3349c3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Baxcalibur remove
+            id: 'f612cbe0-8b28-4f51-9822-7969c039038d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandile remove
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drowzee remove
+            id: 'e3d7e9a1-85cf-471c-86ec-18bf93ecefd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pikachu remove
+            id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skrelp remove
+            id: '0b4905b3-bd2f-4714-bbdb-c88474d52b6f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Oricorio remove
+            id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jynx remove
+            id: 'd93fb92a-f29f-432d-a521-e8a8ea8eb914',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dreepy remove
+            id: '090f5294-3e36-4eb7-a049-a4238f7cfc58',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Malamar remove
+            id: '64dbc2a8-5ec0-4c23-9665-4735eaa97689',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Seviper remove
+            id: 'cad9deea-0d7d-4932-ab18-4c9e699079f6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bronzor remove
+            id: '6ec12acc-3259-41f2-b18c-0c7df67af075',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bidoof remove
+            id: '1480e64d-3e95-454c-bc08-d47d38f742c8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pawniard remove
+            id: 'd5555901-dada-408a-9f19-f402adf9419c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vibrava remove
+            id: '7c6604a5-45f7-4ec1-af48-f5b914fa5802',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Farfetch'd remove
+            id: 'f58c0893-6bb3-4a25-9575-58e62d5d2ccf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Simisear remove
+            id: '556e90c1-1fe0-404d-81cf-108d7ed193a5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Croconaw remove
+            id: '826e4ab3-34d0-4794-a397-80d98b989c09',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pyukumuku remove
+            id: 'ef9ee286-c384-46fe-9d09-597af12cb074',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Voltorb remove
+            id: 'a7ea779c-7360-4fae-a051-3db40f8cbf45',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roggenrola remove
+            id: 'cc0af826-8ee8-426a-bd0b-45bc81f50a1c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drampa remove
+            id: 'c838491d-62e3-4f89-bb2f-b5e15b23065d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Steenee remove
+            id: '79652e74-f9a5-486a-af53-aaec0989354e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowking (Galarian) remove
+            id: '4d61af20-cdb6-49fa-b894-090c84e948cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cacturne remove
+            id: '82fe6639-29b9-4629-873b-9314a2ca4eba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grumpig remove
+            id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pineco remove
+            id: 'da602af9-4a1d-40bf-9042-f943f7241a9d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mareanie remove
+            id: '77f390a4-0d38-434e-af28-8c858e060b3c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Flaaffy remove
+            id: '0bc1956d-f21f-4b11-ba29-ffcf7c3a2cad',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bunnelby remove
+            id: '2749d135-2007-4c12-9046-a7bbcf8116d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grubbin remove
+            id: '509fa83d-48c9-441f-9896-143a602e2454',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spiritomb remove
+            id: '2c8d8545-a6b0-4b95-8870-210410e4be8a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salazzle remove
+            id: 'e2d12702-b64b-461e-88ee-4eebe9a9127b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Claydol remove
+            id: '63e0a668-2ce5-458b-9549-8e1181e2c6b5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Psyduck remove
+            id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Eevee remove
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wailmer remove
+            id: 'd8332cfc-5694-4ab2-9f85-bd3e0e44241b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Araquanid remove
+            id: '99fa0c56-42aa-421c-bb1c-4b264d160f8e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swoobat remove
+            id: '1ec2077c-30c4-4fb6-b2c5-b80064181adb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jangmo-o remove
+            id: '3ef6183e-c053-4b59-9be4-194a784c21a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crustle remove
+            id: 'c21ecb54-6397-4682-88f8-38b85f092bd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wimpod remove
+            id: '794f527e-ee32-4f4d-8b67-12fd54ec7a7b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Honchkrow remove
+            id: '98477623-c2fd-46c2-9fa8-50a2649333f5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noctowl remove
+            id: '3dcca20d-cdd6-4855-b12b-34796c3ac420',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crabominable remove
+            id: '7071a8b0-e642-46b9-a6ab-e063ffd3ce91',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sharpedo remove
+            id: '6513c390-9859-42e3-9cb4-bf114605597d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Purugly remove
+            id: '17335d44-087e-4b9a-ab6c-96852ba46a62',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hitmonlee remove
+            id: '89c759ee-3cda-416b-91de-a8360da73bb3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hitmonchan remove
+            id: '566d8940-0895-4650-bd18-8a40c3b62d11',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Treecko remove
+            id: 'fb117d92-c93d-4a16-ad9f-ac2062325fa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowpoke remove
+            id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Onix remove
+            id: 'e6b8fffd-c432-4df7-85ba-4b8f88593ba7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Persian (Alolan) remove
+            id: '7d8daf9c-d263-4e36-9d57-702e175ef60a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rockruff remove
+            id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dedenne remove
+            id: '55cf5dc5-d8cd-4a8f-a278-7b5eb0d691d6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vulpix (Alolan) remove
+            id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Carnivine remove
+            id: 'a5180789-7e77-4546-bd53-7c12fe4813f1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Plusle remove
+            id: 'c8d27ce2-34e2-42fe-8f9f-0f9298f1a3f7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorunt remove
+            id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nosepass remove
+            id: '31ab0073-5e27-4823-962a-4b47ee976efc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snubbull remove
+            id: 'b46b92fc-56f5-4196-bf35-0d7c2e06c9ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Celebi remove
+            id: '797c6990-9353-43ba-8123-651e344c8e81',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chandelure remove
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Binacle remove
+            id: 'cf95ed17-884e-42bc-bc48-488f64bf874b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ponyta remove
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Diglett remove
+            id: '4adf53ab-0de1-4238-9ddf-ed3f53451967',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gulpin remove
+            id: 'de4cd6ab-6981-4062-ba93-19b285c9baa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hypno remove
+            id: 'e0610027-fbb2-4915-8583-203295d8f06f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Clefairy remove
+            id: '0c1c04e3-9b9a-4b08-a167-516eb398ccc4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cyndaquil remove
+            id: 'ae25232c-f906-4cbb-b8f9-da3a67345154',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magneton remove
+            id: 'c8f5a634-7717-4355-b995-aeabcad506f5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beheeyem remove
+            id: 'be89181f-2d4f-4d03-bb5b-9129351385dc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rufflet remove
+            id: '01346e6f-94e0-41a3-8248-3e6b7f784a04',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Inkay remove
+            id: 'ad5dbc4a-55a2-4da8-a8c5-8d596a14003d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Electrode remove
+            id: '0a3ba008-f8b7-46e4-884c-058c94d9bcf6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Volbeat remove
+            id: 'c0e1b0e4-2b2a-43b8-8d4c-c21c31635bbf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Illumise remove
+            id: '0b30f410-05e9-43c2-a11a-ffa941c2eb7c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Staryu remove
+            id: '3caf5287-84ef-476a-9b3e-9e8a741fe4d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swadloon remove
+            id: '1f85c9c1-6ec1-4062-b8d5-df96564712a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swalot remove
+            id: 'ab2974ee-a499-423b-95b2-1237e6b420dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Scraggy remove
+            id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Forretress remove
+            id: '34eb38f2-8d9c-459c-919e-e31ea735695b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pansear remove
+            id: 'c4ecec83-9656-4194-8c47-5a5b00c10628',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Herdier remove
+            id: '606a490a-00a6-4906-845c-58facd390af8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zorua remove
+            id: '3f78fb44-c9a4-4ab6-bf7f-5cd6ae492fd2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Victini remove
+            id: 'a36f3a56-7601-4860-87fc-c49200535ac3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Emolga remove
+            id: '072f5ec4-189f-4853-8d9d-ce09b70bfa3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidove remove
+            id: '20c0062a-e0b2-4bf5-ae0c-ac4b142c1c54',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Trubbish remove
+            id: 'd3dfc5c5-d610-431e-8d99-8575aca5606e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Audino remove
+            id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Drilbur remove
+            id: '7d21369d-ef48-4b87-94da-66c0456b60c7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Timburr remove
+            id: 'f41d0de3-8989-49fc-a56a-57bf68e9e42c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kricketune remove
+            id: '86bc78c6-4450-41c9-b070-87ccadd9b1c2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kricketot remove
+            id: '507242bb-e2ae-4035-ad7e-c181a256fd6d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hariyama remove
+            id: 'f2ba8919-95f0-46fc-9053-ce1d1af0bd69',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Makuhita remove
+            id: '40d7919e-766c-4109-a5d1-82444c0b63ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tauros remove
+            id: '993d34d3-86e0-4f00-9e9f-ceffc57736f6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Butterfree remove
+            id: '83dc7af6-ad10-47c5-94e2-ce0c754c308f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metapod remove
+            id: 'd921ace6-2cbd-4059-bd62-0057f81b482e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Caterpie remove
+            id: '2558897e-fbf9-462e-b298-99d41d104263',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Burmy remove
+            id: 'da795e59-6f2e-4311-bbba-7e34db7f81a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Croagunk remove
+            id: '8c294829-ea44-4cdc-9456-fed6cfe96151',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gabite remove
+            id: '37ac921e-6004-4c44-9aac-c9eda003224e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Marshtomp remove
+            id: 'de02dc10-ac67-44d2-9497-e929ca243c99',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rhyhorn remove
+            id: '10ce9769-3d89-4403-af38-de246b9d68b5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Munchlax remove
+            id: '0bed20f5-2f40-4dc6-b81b-a7d0bd019133',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shellos remove
+            id: '0091eadb-706c-40d1-ba11-5c95b383b46b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spheal remove
+            id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Banette remove
+            id: 'fad6a4a7-e572-4f07-86ad-39fe31e1ce76',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Poochyena remove
+            id: 'ed1552a1-de0a-4799-87e1-ee0c43ce765d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shelgon remove
+            id: 'daaa9487-42ed-46b6-9dcc-f8d323b6c24e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cherubi remove
+            id: '19618a6b-e347-49ad-a5d5-08582c8bf817',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magikarp remove
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Stunky remove
+            id: 'ba3459b2-c4bc-48a7-99fc-ebe206b07017',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aipom remove
+            id: 'b47d4a57-6547-4a1c-a2bc-4e4aca095d46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metang remove
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Aron remove
+            id: '149b201e-9b77-4c3e-8722-a0be17a89106',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skitty remove
+            id: '89d387dd-40b4-4323-9511-05bf19ec2c6c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slakoth remove
+            id: '41c73fdf-60f6-4139-b418-b226f76199e4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Horsea remove
+            id: 'fe5ce1b9-1969-4c11-8e30-1fbbda7c59af',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dratini remove
+            id: '5209be64-7255-4973-b665-4734ae773e28',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wooper remove
+            id: '6c0bcd91-3e28-4ac2-b0a7-d1c7fde3c87e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dugtrio remove
+            id: 'a51afdb8-235a-4b7b-901d-cf150ada83e1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Krabby remove
+            id: '09c4d189-ee58-44c1-b8c0-9bd51d39dd60',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Furret remove
+            id: 'c29bab69-d99f-40e4-b0a6-cd66bf642472',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kecleon remove
+            id: 'ab0ddce9-051f-425c-8685-824e18f96727',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grimer remove
+            id: 'f1339d6e-5bd4-4974-a746-2db83cfc5542',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sentret remove
+            id: 'b29bd872-719d-4138-be4f-3d839f2496b1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Trapinch remove
+            id: 'ef0701b3-2577-4444-820d-a6ac2412db63',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandshrew remove
+            id: '42a44470-6736-437f-86fe-049202943956',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Taillow remove
+            id: '3bc05b77-1328-4dff-849d-214826190c49',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Phanpy remove
+            id: '5a1de7c3-bcb3-4eb9-8365-e45e404bb023',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sudowoodo remove
+            id: '96df0720-940e-4409-bc83-52c5ed8e2c74',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magcargo remove
+            id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Miltank remove
+            id: '0b8b301c-6871-4ff0-a426-dc881c97790f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slugma remove
+            id: '1d362a45-b7ce-4a05-9d88-90b330422ab2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Camerupt remove
+            id: 'b20ad4e5-9acc-4685-a60c-ae0fad5daf80',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pelipper remove
+            id: '8d36fc6e-c19c-41de-a990-02e218113832',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Carvanha remove
+            id: 'e474b60e-68ec-455e-bb2f-ccf729265b10',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Numel remove
+            id: 'a409c5b6-da3f-4eaf-9963-ec0b59d5bccd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Wingull remove
+            id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Piloswine remove
+            id: '08acf6f6-9442-4568-8c64-629bf7f4100b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Yanma remove
+            id: '123faf97-132f-4a74-b0ad-b5f8aa6b990c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heracross remove
+            id: 'ca1230a9-d936-4410-a015-7fac682cf2cf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Houndour remove
+            id: 'f050feaa-7a93-499a-b7fc-619d579252a0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Swinub remove
+            id: '9dfb92df-d030-412c-9833-d5406c3051e3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Victreebel remove
+            id: 'fc38ae51-f38e-4279-ad4f-593ce9ee615a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weepinbell remove
+            id: 'bb84ab31-c40b-46b2-a60b-09be50ccee67',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bellsprout remove
+            id: 'dc8312f8-9340-414d-a8eb-7e9c6016b715',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exploud remove
+            id: 'a6b4632a-11eb-4a38-9f5e-1abdad5781a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Loudred remove
+            id: '6f645e2e-98e1-448e-b05f-7d6ba8d24e89',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Feebas remove
+            id: 'ea6870c3-3563-4882-b997-7f64aeeea8a8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whismur remove
+            id: '2b445179-b69f-4052-9b3e-496b7d9bb203',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whiscash remove
+            id: 'bc9c4657-6a0e-43ae-a220-94f8c3fb75da',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Barboach remove
+            id: '8dce1004-e075-4ae7-abbe-7a3075864173',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Magnemite remove
+            id: '62831452-5f0d-4836-b608-3c0f052b9889',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lotad remove
+            id: '7f1a5f65-a490-4ef6-9add-b4774f56bc84',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tyrogue remove
+            id: '6c125504-587f-4831-a1e9-e5bb930859eb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ditto remove
+            id: 'd6965153-289e-40ee-aab6-3cf769a1ce2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Granbull remove
+            id: '435a8d08-9103-4ce6-8336-defcb5573a37',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Murkrow remove
+            id: 'b611b2fa-3178-4735-9891-52d9571058bf',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venonat remove
+            id: 'cac2064e-9c81-4536-80d7-9c39af52113e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Primeape remove
+            id: '8b96d379-f31b-4c69-84f0-66f6df3e397f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mankey remove
+            id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgeot remove
+            id: '49b6173d-48a0-4ed2-b15f-3db4ad2058ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Charmeleon remove
+            id: '8997e590-365f-4d2a-b47e-58f0a75d12b8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgeotto remove
+            id: '1e65b346-ffeb-4349-81ee-bfba63894ac3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bulbasaur remove
+            id: '64201a6d-a65c-4ada-8fb9-90c2ba65b294',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cubone remove
+            id: '7dde59c9-3d22-4062-b6fb-b62dc3286abe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pidgey remove
+            id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beedrill remove
+            id: '491bb3c9-59bc-430b-915a-1751e297fa41',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Arbok remove
+            id: '170e3e80-c88f-4f17-bb00-79079a7548ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venomoth remove
+            id: '9d8e9855-9000-41f9-a4c1-abe4d41fe8c8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weezing remove
+            id: 'c5884c42-d169-4c42-b24a-cd35d9ee482a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ariados remove
+            id: '291f1a5f-0754-42d4-a21c-286883f9f642',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shuckle remove
+            id: 'a9056e67-acfe-4264-9f78-06098b5e10dd',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Growlithe remove
+            id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Seadra remove
+            id: '93c3d7dc-9647-46c9-b957-8d90affc6d09',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machoke remove
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rhydon remove
+            id: 'fcaee90c-a915-4d3c-bea1-2f131b78a7ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Koffing remove
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machop remove
+            id: '8a890ca5-12f0-4d54-b1bd-70fe694ea803',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Weedle remove
+            id: 'e4416028-70e0-4dff-bba5-44aca884ac9f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Doduo remove
+            id: 'ff3fc630-2a66-40b0-8a1e-e080951984ff',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Chansey remove
+            id: '1f8758c3-7a15-4661-9519-c151b4fe6dae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Smeargle remove
+            id: 'd19a4e77-6a74-496b-b7f7-9ad96e80d6e7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Machamp remove
+            id: 'c63df320-d4ce-4df6-9f54-f35d079ed19f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Omastar remove
+            id: '12dd5353-d2c8-4085-86d0-6ba5d53570fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowking remove
+            id: '90ccd9b5-6b50-4784-a740-2fae543a0787',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ledian remove
+            id: '2979f112-6e54-442f-b55d-5a6d73520fe0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Omanyte remove
+            id: '0d153819-8caa-4109-8697-269cd778010e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Slowbro remove
+            id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ledyba remove
+            id: '87e6d3f7-97a0-4117-ada9-4dcb9d718b6f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Delibird remove
+            id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Octillery remove
+            id: '968ac154-1faa-4628-9364-03381d65b61a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Politoed remove
+            id: 'e54aa090-763f-44e6-9917-09aabbc17618',
             type: 'pokemon'
           }
         }
@@ -409,7 +7523,400 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Smeargle remove
+            id: 'd19a4e77-6a74-496b-b7f7-9ad96e80d6e7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bronzong remove
+            id: '83bbb185-e67b-43ca-90f2-01ff86bc5b8a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Snorlax remove
+            id: '27194e95-3472-4247-8cc2-6dfa1eb42e46',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Metagross remove
+            id: '4ba7f825-c1f4-4a92-9cd8-57d97a31ec0f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Toxicroak remove
+            id: '0ea31ecd-67a0-4f28-8cec-7dd3e4154ed6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Salamence remove
+            id: 'f0fd16ea-5aa5-4c90-bdf4-447dc0c6a75d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Empoleon remove
+            id: '2097e1f6-3330-4663-8a56-fef5995b075c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kyogre remove
+            id: '3bb1a893-8647-4227-8624-874b958f7e74',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hariyama remove
+            id: 'f2ba8919-95f0-46fc-9053-ce1d1af0bd69',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dialga remove
+            id: 'ae79d2b8-50fa-4ddb-ac8b-42c2563ba265',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cresselia remove
+            id: '4f2c7a28-29f2-40b4-9492-13e408a0dd6e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Groudon remove
+            id: 'd37e2a0b-a724-4775-bf45-4435055c340f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Thundurus remove
+            id: 'b6cc1169-cc23-491f-982d-0071d6d02d10',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gothitelle remove
+            id: '93fac96d-70a5-46a4-b450-0a0491b5130c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Conkeldurr remove
+            id: '993e5d2d-a310-4335-86e3-f65d75523390',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Terrakion remove
+            id: '1f894962-6395-4170-b4d8-6fb23e61a8cc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hydreigon remove
+            id: '31268946-ec91-435d-a931-a93445e22b9b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Escavalier remove
+            id: 'f2c2f270-4515-40b5-8f42-7a2db6cff048',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Garchomp remove
+            id: '5dd77001-2ef6-430d-a2f8-2888ca242de2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rotom remove
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tyranitar remove
+            id: 'e0d725b1-cfc6-4b87-b302-b42a16f8ff67',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tornadus remove
+            id: '5fba772a-8abf-4c0d-9955-9544ff27a2d9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Mamoswine remove
+            id: '0a7c7eba-cc15-4542-8394-f1646442ebe1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Latios remove
+            id: '631eefb3-d7cd-4f8c-a9f5-f5b8462bd691',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Heatran remove
+            id: '16b10976-e656-46d4-becb-eddc4093a33e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Pachirisu remove
+            id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Talonflame remove
+            id: 'ea5ad89e-aa20-40e3-89a3-291a753b290f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gardevoir remove
+            id: 'e960f9ed-c9ac-4eb5-80f4-c79f33bcbdc3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gyarados remove
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kangaskhan remove
+            id: 'b0d49348-e3bb-42da-9153-999e3a5aa68b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Landorus remove
+            id: '72fa9385-3372-4e53-9fc6-086a9c34d5fe',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hitmontop remove
+            id: '2adc5b47-33db-4305-b6a5-89199907b36d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Raichu remove
+            id: 'd8dc6dee-40f9-46dd-aff4-c471c7697cc8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rayquaza remove
+            id: '0171898c-529c-4d3c-8be2-54c578cd54f9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gengar remove
+            id: 'aeebb5d0-0e9c-4627-8b94-0c6205b112a6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tapu Koko remove
+            id: '31b8fdb5-36af-4f50-a593-2b2387faec01',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tapu Fini remove
+            id: '045b384a-627d-48fc-89b2-969d75cef8ba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Marowak remove
+            id: '71abf713-5e5f-457a-a3d6-d72c8e400fc5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Krookodile remove
+            id: '61f6726c-cab5-4fc0-a193-a8f269d3ccd7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Incineroar remove
+            id: 'a2af4292-af32-4d85-a791-2cec9601726b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kartana remove
+            id: '46afaa00-9080-461c-bb0c-c8ec974b4931',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gastrodon remove
+            id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Togekiss remove
+            id: '8f95aee6-776a-4df8-9c67-86ec9c7345d3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Rillaboom remove
+            id: '81f20cbc-e206-46cb-8114-65e6a5637fbb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dragapult remove
+            id: '5597de67-0458-4eee-a571-3ed56febf4ef',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Urshifu remove
+            id: '5da303c7-e2b2-47ee-be17-51812f0609d5',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Coalossal remove
+            id: '10b5a001-5bd8-4b31-a03a-823be1ffa0ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Moltres (Galarian) remove
+            id: '56b91991-57d7-488b-a86a-a22c1f3581fc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grimmsnarl remove
+            id: '1f47e8fa-7a54-4ed1-bf39-ce20e4fdaf3e',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Venusaur remove
+            id: 'a8dbb05c-c751-4605-af23-5f5d217870ab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Torkoal remove
+            id: 'e93f217e-55a5-484f-8ec8-43d507a4a0bb',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Regieleki remove
+            id: '1d12f572-4220-40c6-a5ce-fd19e9eeaa84',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Moltres remove
+            id: 'dcc2697f-e855-43bc-bd4b-082e484b0605',
             type: 'pokemon'
           }
         }
@@ -461,7 +7968,512 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       validPokemon: [
         {
           data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+            // Zubat remove
+            id: '7702c983-82e2-4133-b77f-720fdd1a3187',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Golbat remove
+            id: 'c61e4369-1e15-4bfe-a519-a856e5c69cf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Oddish remove
+            id: '639f5cf6-3c4c-410e-abe6-5fda5c9cc39b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Gloom remove
+            id: 'eada1550-419b-4cc8-b18b-10b66e59911b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Vileplume remove
+            id: '98547c35-7602-4b40-b88a-31e7cf88fee7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggcute remove
+            id: '4eca9e98-13d2-4dba-bcc9-14678e906303',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Exeggutor remove
+            id: 'e56f7d17-06d6-4f98-aa2a-462453331e0b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tangela remove
+            id: '789dbd72-3aa0-4ee5-a2f6-fb5de2c32f8f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kabuto remove
+            id: '79fbda43-7ad3-4907-a8ba-0af028f4ae5b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kabutops remove
+            id: 'c05e94e7-7718-4520-b94b-df4c70274bdc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Crobat remove
+            id: '9f4fba50-30df-4cd5-8ec2-352c5fd386ae',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Bellossom remove
+            id: 'a02e9412-2687-4900-a640-74aacf037e1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lotad remove
+            id: '7f1a5f65-a490-4ef6-9add-b4774f56bc84',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lombre remove
+            id: 'b961354a-9eb9-4142-9739-51388d02a0ff',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ludicolo remove
+            id: '3321508f-6cb2-4790-abb7-984a5a297310',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Seedot remove
+            id: '791964e7-c59a-4cfe-8f13-caf2c6be8b50',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nuzleaf remove
+            id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shiftry remove
+            id: '17fcfde4-cf74-439f-b708-31a9994a0fab',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Nincada remove
+            id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ninjask remove
+            id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shedinja remove
+            id: '91299325-9853-42fe-9042-3d293409638d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roselia remove
+            id: '9dd46130-0bee-488b-9648-4bfdba3630ea',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Budew remove
+            id: '1c163023-ac99-4cec-bf9a-75e7bc69fef2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Roserade remove
+            id: '67f1990d-2c87-4efa-815f-539a576ceca1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Tangrowth remove
+            id: '9d9cc213-da86-46c2-8b1a-9d0cc7a67a2b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cottonee remove
+            id: 'f9a9813e-75ba-4cfb-a30c-632826b4cdf1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Whimsicott remove
+            id: '4858f688-d18a-4d0d-92f7-f75d84721363',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Petilil remove
+            id: '34294645-8d12-4314-bbf7-ff68ed5bc199',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Lilligant remove
+            id: 'b7c59530-c0b0-4fd8-b94e-0c1cdc264069',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Maractus remove
+            id: '7af0e968-d555-4acb-b030-8fdd64600615',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Foongus remove
+            id: 'c4b2847c-be81-4f64-9e0c-2de01cadca38',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Amoonguss remove
+            id: '95cca9c6-7f19-494c-b105-5121cfa13b1f',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Frillish remove
+            id: '57c806ec-5047-47ae-be92-d57ac98903b8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jellicent remove
+            id: 'bd00b00a-d2fe-4b3f-ad2b-5496dc3a5743',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Joltik remove
+            id: '71c6b9df-1cdb-49e2-b157-a3df7bcf68ed',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Galvantula remove
+            id: '488d87d2-36ee-4472-a001-6d99ca709846',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shelmet remove
+            id: 'f8cd280f-a0ac-497f-bd72-7fffb4fa07b8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Accelgor remove
+            id: '5e598939-b6d8-4d85-8b6c-496e61eadc72',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Goomy remove
+            id: '56c95763-648b-4526-a580-e5f4487c0665',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sliggoo remove
+            id: '9623145b-b828-4d6a-8d81-856502affcf7',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Goodra remove
+            id: '36ed9371-57f3-4aef-bd23-47230a25569b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noibat remove
+            id: '187dfec5-b0cb-4157-a4aa-4738241e0864',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Noivern remove
+            id: '129f1e87-418d-4b4e-b19b-c574acd5b0f3',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cutiefly remove
+            id: 'f590d249-312f-409a-b606-bbadf1228aa2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ribombee remove
+            id: '989bd543-5276-41ac-80c5-004d42bae3d8',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Morelull remove
+            id: '56832305-894d-487e-99a5-493f7e97961b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shiinotic remove
+            id: '72700d35-b5bc-4aa1-b279-4c4e33488e9d',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sandygast remove
+            id: '33cd3f2a-b8cb-48ca-9944-eb6b79418802',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Palossand remove
+            id: 'c7ffe447-807d-4a54-8358-3e50a066430c',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Dhelmise remove
+            id: '5dc264bb-a2ef-4b69-b9bb-173bee44eea4',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Celesteela remove
+            id: 'af53510d-482f-4c27-91d8-ab3a388f6d88',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Paras remove
+            id: 'd5a53a34-f2a8-4ba9-af97-005b34807cb6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Parasect remove
+            id: '286b3fa7-8124-41ba-88b9-210b1d135d55',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Spinarak remove
+            id: '16b77d80-6e39-4faf-a51d-0f218fbdc1d0',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Ariados remove
+            id: '291f1a5f-0754-42d4-a21c-286883f9f642',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Hoppip remove
+            id: '45458f0f-3118-4b87-a148-bee667717bc2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Skiploom remove
+            id: '2d4d57dd-0442-4241-b09f-875e07606598',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Jumpluff remove
+            id: 'faddd5f7-0e8c-41fb-9771-2f15fc571bba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sunkern remove
+            id: '509aa4ab-b4b6-4d73-a7f2-211f66aa3649',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sunflora remove
+            id: '148a6ef8-5d26-42cf-bcfd-48dd25b4a54b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Beautifly remove
+            id: '3915fc76-11d2-4e19-b062-5ca49ccbd180',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Shroomish remove
+            id: 'f20df009-de8b-4983-a8d8-ce86f339b03b',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Breloom remove
+            id: '697d384b-63a8-48dc-8722-387534e52750',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cacnea remove
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Cacturne remove
+            id: '82fe6639-29b9-4629-873b-9314a2ca4eba',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grotle remove
+            id: '259a773b-f770-47ec-9459-59bd20cc2711',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Torterra remove
+            id: '16089a5e-4004-4c13-96ad-64197b0b35d6',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Kricketune remove
+            id: '86bc78c6-4450-41c9-b070-87ccadd9b1c2',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Treecko remove
+            id: 'fb117d92-c93d-4a16-ad9f-ac2062325fa9',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Grovyle remove
+            id: '9a2ff038-9d5f-4c32-825a-7487003bcbfa',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Sceptile remove
+            id: 'e0accc9e-65f4-4e45-8ad4-7ed0559b1fc1',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Larvesta remove
+            id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+            type: 'pokemon'
+          }
+        },
+        {
+          data: {
+            // Volcarona remove
+            id: '149043bb-0730-4320-bdc6-fa219e308223',
             type: 'pokemon'
           }
         }
@@ -562,14 +8574,7 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '1e665730-88cd-4ca3-b03c-961c3a71e749', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2022', type: 'year' } }
     }
   }
@@ -588,14 +8593,7 @@ export const competitionsData2022: { [id: string]: ICompetitionEntity } = {
       selectedBy: {
         data: { id: '1e665730-88cd-4ca3-b03c-961c3a71e749', type: 'player' }
       },
-      validPokemon: [
-        {
-          data: {
-            id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
-            type: 'pokemon'
-          }
-        }
-      ],
+      validPokemon: [],
       year: { data: { id: '2022', type: 'year' } }
     }
   }

--- a/src/data/points/2017/01.data.ts
+++ b/src/data/points/2017/01.data.ts
@@ -4,34 +4,6 @@ import { MethodType } from "src/types/method.types";
 import { IPointEntities } from "store/reducers";
 
 export const pointsData2017_1:IPointEntities = {
-  'b6ca0559-bf59-4e82-a3e5-40c946c66960': {
-  data: {
-    id: 'b6ca0559-bf59-4e82-a3e5-40c946c66960',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'e311d650-1193-475f-bd08-97b3c96c8626',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'dba308cb-887e-4db2-913a-3a80caacd932', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'a2a015a4-24b5-4ad2-87be-ce8817a8329e', type: 'pokemon' }
-      }
-    }
-  }
-},
   '129b5cb2-db60-416a-86de-e5a9a17f407c': {
   data: {
     id: '129b5cb2-db60-416a-86de-e5a9a17f407c',
@@ -207,63 +179,7 @@ export const pointsData2017_1:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'e311d650-1193-475f-bd08-97b3c96c8626',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e99aa0f1-460c-499f-9c39-0279a7490881', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '261ed503-81a1-431c-9acd-bf5fac7812eb': {
-  data: {
-    id: '261ed503-81a1-431c-9acd-bf5fac7812eb',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'e311d650-1193-475f-bd08-97b3c96c8626',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e99aa0f1-460c-499f-9c39-0279a7490881', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '76e5d334-a0f2-49be-a9ad-c82c1a0489e6': {
-  data: {
-    id: '76e5d334-a0f2-49be-a9ad-c82c1a0489e6',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2017/02.data.ts
+++ b/src/data/points/2017/02.data.ts
@@ -39,7 +39,7 @@ export const pointsData2017_2:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -53,90 +53,6 @@ export const pointsData2017_2:IPointEntities = {
       },
       player: {
         data: { id: '938a3ab8-2b5a-4666-bc53-5e6c284ec323', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '52a6f371-58db-451b-bcad-414fbda4ae75', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'a858030b-b155-458d-ac41-4f463e09ee1f': {
-  data: {
-    id: 'a858030b-b155-458d-ac41-4f463e09ee1f',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b9c43ce7-83e8-48be-b330-650f4128e720',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '938a3ab8-2b5a-4666-bc53-5e6c284ec323', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '52a6f371-58db-451b-bcad-414fbda4ae75', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'e8fe9628-f546-4055-b225-dda8fa5b70ff': {
-  data: {
-    id: 'e8fe9628-f546-4055-b225-dda8fa5b70ff',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b9c43ce7-83e8-48be-b330-650f4128e720',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '938a3ab8-2b5a-4666-bc53-5e6c284ec323', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '52a6f371-58db-451b-bcad-414fbda4ae75', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '8f193d8e-9666-4a8a-839a-af4396a35011': {
-  data: {
-    id: '8f193d8e-9666-4a8a-839a-af4396a35011',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b9c43ce7-83e8-48be-b330-650f4128e720',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '39e79433-2e7a-490e-ac86-26f076d64a5d', type: 'player' }
       },
       pokemon: {
         data: { id: '52a6f371-58db-451b-bcad-414fbda4ae75', type: 'pokemon' }

--- a/src/data/points/2017/03.data.ts
+++ b/src/data/points/2017/03.data.ts
@@ -67,63 +67,7 @@ export const pointsData2017_3:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b07a6390-716a-4163-827d-72d23caecde5',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '39e79433-2e7a-490e-ac86-26f076d64a5d', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'c36f780b-5769-407b-9600-921d57ace904', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '3b805089-99a6-48ae-95db-7fd83213c8a0': {
-  data: {
-    id: '3b805089-99a6-48ae-95db-7fd83213c8a0',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b07a6390-716a-4163-827d-72d23caecde5',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '39e79433-2e7a-490e-ac86-26f076d64a5d', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'c36f780b-5769-407b-9600-921d57ace904', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'ab963059-ffaf-4f79-9272-35eadf73a781': {
-  data: {
-    id: 'ab963059-ffaf-4f79-9272-35eadf73a781',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -175,34 +119,6 @@ export const pointsData2017_3:IPointEntities = {
   '32c3c140-bdcd-4b32-80f3-feabd2e3ba3b': {
   data: {
     id: '32c3c140-bdcd-4b32-80f3-feabd2e3ba3b',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b07a6390-716a-4163-827d-72d23caecde5',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'f590d249-312f-409a-b606-bbadf1228aa2', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '871618fd-f4fe-4b94-8ad5-6813e2ff238c': {
-  data: {
-    id: '871618fd-f4fe-4b94-8ad5-6813e2ff238c',
     type: 'point',
     attributes: {
       ball: null,

--- a/src/data/points/2017/04.data.ts
+++ b/src/data/points/2017/04.data.ts
@@ -60,34 +60,6 @@ export const pointsData2017_4:IPointEntities = {
     }
   }
 },
-  '510c0a7c-2ab6-4050-8e6f-6a503c8a4953': {
-  data: {
-    id: '510c0a7c-2ab6-4050-8e6f-6a503c8a4953',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b05827a2-15ec-4f82-a763-9e15f0f4580f',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '2e27852c-5a81-4b6c-b7f2-38bb094ac439', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9', type: 'pokemon' }
-      }
-    }
-  }
-},
   'e07aab9a-cb9f-4109-9062-944b28cf240d': {
   data: {
     id: 'e07aab9a-cb9f-4109-9062-944b28cf240d',
@@ -123,63 +95,7 @@ export const pointsData2017_4:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b05827a2-15ec-4f82-a763-9e15f0f4580f',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '79772b9b-a982-49d4-add0-354503df9c9e': {
-  data: {
-    id: '79772b9b-a982-49d4-add0-354503df9c9e',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: 'b05827a2-15ec-4f82-a763-9e15f0f4580f',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e06311f7-1452-49e3-8660-2c9e4cc98aa9', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '94ec1317-058e-4864-9365-2dfbc1d5fd67': {
-  data: {
-    id: '94ec1317-058e-4864-9365-2dfbc1d5fd67',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2017/05.data.ts
+++ b/src/data/points/2017/05.data.ts
@@ -32,34 +32,6 @@ export const pointsData2017_5:IPointEntities = {
     }
   }
 },
-  '0e68e4e1-640a-4f56-9fd9-d3b6111ba300': {
-  data: {
-    id: '0e68e4e1-640a-4f56-9fd9-d3b6111ba300',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '68d90ecc-b5fa-4080-8705-e3c6f06606ae',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '938a3ab8-2b5a-4666-bc53-5e6c284ec323', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '138e873d-db9b-4f2b-bd9a-59757b9282e8', type: 'pokemon' }
-      }
-    }
-  }
-},
   'ecfea6c7-b3bd-4c88-be68-43e028bb4cbf': {
   data: {
     id: 'ecfea6c7-b3bd-4c88-be68-43e028bb4cbf',
@@ -123,63 +95,7 @@ export const pointsData2017_5:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '68d90ecc-b5fa-4080-8705-e3c6f06606ae',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '758c86f7-e08f-4aa7-ac55-a345669ad53a', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '3d166d39-830d-427f-aa78-07e494157acc': {
-  data: {
-    id: '3d166d39-830d-427f-aa78-07e494157acc',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '68d90ecc-b5fa-4080-8705-e3c6f06606ae',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '80cfecae-ef2e-437b-bb94-f0309ee3b3d2', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '758c86f7-e08f-4aa7-ac55-a345669ad53a', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '93332c3b-79ea-40db-ad69-49bd293de6a8': {
-  data: {
-    id: '93332c3b-79ea-40db-ad69-49bd293de6a8',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2017/07.data.ts
+++ b/src/data/points/2017/07.data.ts
@@ -39,63 +39,7 @@ export const pointsData2017_7:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '6a1a6b30-6467-4e94-8a03-021dba4bee7c',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '2e27852c-5a81-4b6c-b7f2-38bb094ac439', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '91fcbb79-4982-42b8-bd81-2270bb7a6195': {
-  data: {
-    id: '91fcbb79-4982-42b8-bd81-2270bb7a6195',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '6a1a6b30-6467-4e94-8a03-021dba4bee7c',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '2e27852c-5a81-4b6c-b7f2-38bb094ac439', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'b94ec2fd-2df5-4027-8227-6ae084065514': {
-  data: {
-    id: 'b94ec2fd-2df5-4027-8227-6ae084065514',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2017/09.data.ts
+++ b/src/data/points/2017/09.data.ts
@@ -39,63 +39,7 @@ export const pointsData2017_9:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '8747fcc1-1b22-4be4-8137-a6660bcae823',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'c43593fd-054d-4515-b1a7-65d4ce43bebb': {
-  data: {
-    id: 'c43593fd-054d-4515-b1a7-65d4ce43bebb',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '8747fcc1-1b22-4be4-8137-a6660bcae823',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '1b00e025-b3ea-45d1-9041-37724b5626cf': {
-  data: {
-    id: '1b00e025-b3ea-45d1-9041-37724b5626cf',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
+      firstCatch: true,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2018/01.data.ts
+++ b/src/data/points/2018/01.data.ts
@@ -39,7 +39,7 @@ export const pointsData2018_1:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2018/12.data.ts
+++ b/src/data/points/2018/12.data.ts
@@ -88,6 +88,40 @@ export const pointsData2018_12:IPointEntities = {
     }
   }
 },
+'6ea71e91-329c-4b22-9357-3bd228de51ad': {
+    data: {
+      id: '6ea71e91-329c-4b22-9357-3bd228de51ad',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: null,
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '7ae560d8-6741-454d-a76f-cd215a186728',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '8664bc55-da05-4069-9e68-7512901224ac',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  },
   '1ba99ec0-b9b1-4276-a6d6-98e66f06102f': {
   data: {
     id: '1ba99ec0-b9b1-4276-a6d6-98e66f06102f',

--- a/src/data/points/2018/18.data.ts
+++ b/src/data/points/2018/18.data.ts
@@ -256,4 +256,38 @@ export const pointsData2018_18:IPointEntities = {
     }
   }
 },
+'bcbb004f-0d62-439a-af80-01da5e60a0ed': {
+    data: {
+      id: 'bcbb004f-0d62-439a-af80-01da5e60a0ed',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2025-02-22',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '528d8774-e285-4501-8041-fd012d7fbc95',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '50029136-4d47-43f3-aaf2-9f290f60fd26',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '7cf0d871-ba20-4ba1-a530-8145903c07c1',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  },
 }

--- a/src/data/points/2019/01.data.ts
+++ b/src/data/points/2019/01.data.ts
@@ -39,7 +39,7 @@ export const pointsData2019_1:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2019/04.data.ts
+++ b/src/data/points/2019/04.data.ts
@@ -39,7 +39,7 @@ export const pointsData2019_4:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2019/17.data.ts
+++ b/src/data/points/2019/17.data.ts
@@ -11,7 +11,7 @@ export const pointsData2019_17:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2019/19.data.ts
+++ b/src/data/points/2019/19.data.ts
@@ -11,7 +11,7 @@ export const pointsData2019_19:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2019/22.data.ts
+++ b/src/data/points/2019/22.data.ts
@@ -11,7 +11,7 @@ export const pointsData2019_22:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -83,7 +83,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: '136dffcb-c364-4d04-96f7-e59d54eb88fb', type: 'player' }
       },
       pokemon: {
-        data: { id: 'fd68bfbd-da6e-4df4-9d00-e549d1638fd3', type: 'pokemon' }
+        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
@@ -139,7 +139,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: 'aa85175c-0613-4d07-a465-7b068c3f82ad', type: 'pokemon' }
       }
     }
   }
@@ -167,7 +167,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: '393d6b71-0af9-4876-b37c-e2470ea37f3c', type: 'pokemon' }
       }
     }
   }
@@ -195,7 +195,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: '45608793-1fd4-4596-8fa8-51d8ab0205d9', type: 'pokemon' }
       }
     }
   }
@@ -223,7 +223,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: 'a24b0474-d65d-4601-824f-7f2cefbf52d9', type: 'pokemon' }
       }
     }
   }
@@ -251,7 +251,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
@@ -279,7 +279,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '7b16a8cc-41ec-41d5-b04e-69e77765777e', type: 'pokemon' }
+        data: { id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b', type: 'pokemon' }
       }
     }
   }
@@ -363,7 +363,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: '238a9a85-7020-480f-bb8b-b0d4278b52b7', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: { id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432', type: 'pokemon' }
       }
     }
   }
@@ -391,7 +391,7 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: '238a9a85-7020-480f-bb8b-b0d4278b52b7', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
@@ -447,487 +447,669 @@ export const pointsData2019_22:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'ba0263f4-41f8-4f59-bdfd-328e72f8dbe4': {
-  data: {
-    id: 'ba0263f4-41f8-4f59-bdfd-328e72f8dbe4',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '5e2fb801-62fc-4453-bf46-ad2cafb25539': {
-  data: {
-    id: '5e2fb801-62fc-4453-bf46-ad2cafb25539',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'bfac46b1-6e9f-45f5-a704-61059006e991': {
-  data: {
-    id: 'bfac46b1-6e9f-45f5-a704-61059006e991',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'e6879810-c5de-4ce3-be7a-3a2bd198766f': {
-  data: {
-    id: 'e6879810-c5de-4ce3-be7a-3a2bd198766f',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '5aaa23fb-cd23-46eb-a669-588ab6af629a': {
-  data: {
-    id: '5aaa23fb-cd23-46eb-a669-588ab6af629a',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'c112169d-ce6b-46df-be76-5b1da2028084': {
-  data: {
-    id: 'c112169d-ce6b-46df-be76-5b1da2028084',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  '9c7f3d02-6d9f-4814-93ca-f0980a0ef67d': {
-  data: {
-    id: '9c7f3d02-6d9f-4814-93ca-f0980a0ef67d',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'dbe15d76-c258-4fc8-adfb-922199aec051': {
-  data: {
-    id: 'dbe15d76-c258-4fc8-adfb-922199aec051',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
-      },
-      pokemon: {
         data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
 },
-  'd8c30606-f123-4429-9d02-a18cc90a1e1c': {
-  data: {
-    id: 'd8c30606-f123-4429-9d02-a18cc90a1e1c',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+ //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0326. Grumpig 
+  '5499b2b4-e9c4-443d-b152-8260e73f9b2d': {
+    data: {
+      id: '5499b2b4-e9c4-443d-b152-8260e73f9b2d',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'fa009529-a4e8-43fc-ad1f-f3dacc7a5e85',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
-},
-  'c8474384-dcc3-42f4-871d-16cd88331e5f': {
-  data: {
-    id: 'c8474384-dcc3-42f4-871d-16cd88331e5f',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0195. Quagsire 
+  '1ce4be1a-9243-4ef0-9ec2-5646902a86dd': {
+    data: {
+      id: '1ce4be1a-9243-4ef0-9ec2-5646902a86dd',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '90753663-6eaf-460f-b3df-a56773333783',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
-},
-  'be5fb641-268e-4b16-af50-d219f6968682': {
-  data: {
-    id: 'be5fb641-268e-4b16-af50-d219f6968682',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0419. Floatzel 
+  'adf72639-5cb6-4148-8a4c-63ad26bcc09a': {
+    data: {
+      id: 'adf72639-5cb6-4148-8a4c-63ad26bcc09a',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'a64b7e5c-daa7-47b1-8db8-7db7e4ed91fd',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
-},
-  'e1e854dd-2e54-4edf-b3e9-ba5be2090796': {
-  data: {
-    id: 'e1e854dd-2e54-4edf-b3e9-ba5be2090796',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0334. Altaria 
+  '3b290637-3f6d-4d59-a476-90fca0539450': {
+    data: {
+      id: '3b290637-3f6d-4d59-a476-90fca0539450',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '58fb2cb0-d32c-4f28-a142-68c74ba71b70',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '494c864d-773a-4707-8aec-a26e87c8f3a6', type: 'pokemon' }
       }
     }
   }
-},
-  '6f43a69b-6ac7-44a5-9c3b-a6f130b910c8': {
-  data: {
-    id: '6f43a69b-6ac7-44a5-9c3b-a6f130b910c8',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0277. Swellow 
+  'dbdd42a1-4893-443c-95de-11071af682cf': {
+    data: {
+      id: 'dbdd42a1-4893-443c-95de-11071af682cf',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '9adfc810-90e2-47c0-af33-e11897395efd',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71', type: 'pokemon' }
       }
     }
   }
-},
-  '2571a532-ec11-400a-b5d0-308d71b81ede': {
-  data: {
-    id: '2571a532-ec11-400a-b5d0-308d71b81ede',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0077. Ponyta 
+  '704cb142-2e5f-4436-8a1b-a22df64367ef': {
+    data: {
+      id: '704cb142-2e5f-4436-8a1b-a22df64367ef',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '3a1f8e0e-ad15-49d3-b4fc-ccfffbf2bf2f',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71', type: 'pokemon' }
       }
     }
   }
-},
-  '23363d20-1ced-4a1e-8143-8dd885af569e': {
-  data: {
-    id: '23363d20-1ced-4a1e-8143-8dd885af569e',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Nama Chibitty (@NamaTheNerd) 
+  //  0078. Rapidash 
+  'fbc724cd-4c3d-42d2-aa41-98580cef3809': {
+    data: {
+      id: 'fbc724cd-4c3d-42d2-aa41-98580cef3809',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '46667a68-d44d-4e3c-9822-d3a8e38157a7',
+            type: 'pokemon'
+          }
         }
+      }
+    }
+  },
+       
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Devilish Inferno (@Alex) 
+  //  0129. Magikarp 
+  '559c7c87-4635-4d93-8704-98a34e27c647': {
+    data: {
+      id: '559c7c87-4635-4d93-8704-98a34e27c647',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
       },
-      player: {
-        data: { id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71', type: 'pokemon' }
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
       }
     }
   }
-},
-  '9ab541bf-b158-42d1-bbfc-d3477f12e417': {
-  data: {
-    id: '9ab541bf-b158-42d1-bbfc-d3477f12e417',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Devilish Inferno (@Alex) 
+  //  0813. Scorbunny 
+  'bcbde81f-30fa-400a-b0f6-1cca4e89482d': {
+    data: {
+      id: 'bcbde81f-30fa-400a-b0f6-1cca4e89482d',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '04182a98-03e1-4072-84c5-e3c84a6891dd',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71', type: 'pokemon' }
       }
     }
   }
-},
-  '71c0bf33-c682-43a0-88c0-e9b08d7601cc': {
-  data: {
-    id: '71c0bf33-c682-43a0-88c0-e9b08d7601cc',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
-          type: 'competition'
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Devilish Inferno (@Alex) 
+  //  0835. Yamper 
+  'f51c1740-e084-4af9-94dc-1a79ecc37359': {
+    data: {
+      id: 'f51c1740-e084-4af9-94dc-1a79ecc37359',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'e6a04cee-d60c-4e0e-9306-eafc52020b62',
+            type: 'pokemon'
+          }
         }
-      },
-      player: {
-        data: { id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49', type: 'player' }
-      },
-      pokemon: {
-        data: { id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71', type: 'pokemon' }
       }
     }
   }
-},
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Devilish Inferno (@Alex) 
+  //  0679. Honedge 
+  '7c6d94d8-140a-4479-abee-2d03367326eb': {
+    data: {
+      id: '7c6d94d8-140a-4479-abee-2d03367326eb',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '0633d25c-8f26-4049-8403-407ff49b7a1d',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  }
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Devilish Inferno (@Alex) 
+  //  0130. Gyarados 
+  '9d32f8e4-9245-459e-a21f-23ab397d0bf8': {
+    data: {
+      id: '9d32f8e4-9245-459e-a21f-23ab397d0bf8',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  },
+//  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Steve (@sbj) 
+  //  0607. Litwick 
+  '8c3e0dbc-7aae-48fc-8a42-865c9310cd0d': {
+    data: {
+      id: '8c3e0dbc-7aae-48fc-8a42-865c9310cd0d',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  }
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Steve (@sbj) 
+  //  0608. Lampent 
+  '6cc9b83f-a43d-458c-adb3-209559bae628': {
+    data: {
+      id: '6cc9b83f-a43d-458c-adb3-209559bae628',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'a45ed20d-d26d-4f3b-97f4-385648af42b3',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  }
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Steve (@sbj) 
+  //  0609. Chandelure 
+  'dfea46e5-1fa5-456f-89e8-d089fb55b401': {
+    data: {
+      id: 'dfea46e5-1fa5-456f-89e8-d089fb55b401',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: 'dc11989f-1d37-4101-860e-9d18863fbeef',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  }
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Steve (@sbj) 
+  //  0129. Magikarp 
+  '709a8ea7-175d-4cc9-ade0-834739476fef': {
+    data: {
+      id: '709a8ea7-175d-4cc9-ade0-834739476fef',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '494c864d-773a-4707-8aec-a26e87c8f3a6',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  }
+,
+
+  //  Catch 'em All Dec 14, 2019 to Dec 31, 2019
+  //  Steve (@sbj) 
+  //  0130. Gyarados 
+  'fcb54aac-11a6-4ded-936b-de50dd175875': {
+    data: {
+      id: 'fcb54aac-11a6-4ded-936b-de50dd175875',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2019-12-16',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: true
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76545ac2-64f6-413d-9fa1-3cc8c5809d76',
+            type: 'competition'
+          }
+        },
+        player: {
+          data: {
+            id: 'dc7bd870-037f-45d8-bf8d-3e98a361cf49',
+            type: 'player'
+          }
+        },
+        pokemon: {
+          data: {
+            id: '9ee2c16a-577f-4cc8-8839-1a4116c7480b',
+            type: 'pokemon'
+          }
+        }
+      }
+    }
+  },
   '3826309f-4ac6-4350-ad18-ce1a2faad221': {
   data: {
     id: '3826309f-4ac6-4350-ad18-ce1a2faad221',

--- a/src/data/points/2019/23.data.ts
+++ b/src/data/points/2019/23.data.ts
@@ -11,7 +11,7 @@ export const pointsData2019_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/01.data.ts
+++ b/src/data/points/2020/01.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_1:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/02.data.ts
+++ b/src/data/points/2020/02.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_2:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/03.data.ts
+++ b/src/data/points/2020/03.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_3:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -284,32 +284,5 @@ export const pointsData2020_3:IPointEntities = {
     }
   }
 },
-  'b9447347-444e-4972-a4fe-468c2135129f': {
-  data: {
-    id: 'b9447347-444e-4972-a4fe-468c2135129f',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '88518b90-60ef-42ff-9bd1-ff13b98fa601',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'b977ef18-feea-41cb-8fd6-67512595ec32', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '487c56e5-9319-46a0-81bb-1666d9219e45', type: 'pokemon' }
-      }
-    }
-  }
-},
+
 }

--- a/src/data/points/2020/04.data.ts
+++ b/src/data/points/2020/04.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_4:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -252,34 +252,6 @@ export const pointsData2020_4:IPointEntities = {
       },
       pokemon: {
         data: { id: '1f8758c3-7a15-4661-9519-c151b4fe6dae', type: 'pokemon' }
-      }
-    }
-  }
-},
-  'cb0712f0-c288-48c2-a6bf-1d95a88732f2': {
-  data: {
-    id: 'cb0712f0-c288-48c2-a6bf-1d95a88732f2',
-    type: 'point',
-    attributes: {
-      ball: null,
-      catchDate: null,
-      firstCatch: false,
-      game: null,
-      method: null,
-      oldSystemPoint: true
-    },
-    relationships: {
-      competition: {
-        data: {
-          id: '71284cf5-082b-4fd6-b479-518eeb9a8da1',
-          type: 'competition'
-        }
-      },
-      player: {
-        data: { id: 'e4bd5ce2-115d-488a-b63c-07d0e34de752', type: 'player' }
-      },
-      pokemon: {
-        data: { id: '6cbfb9db-915f-4874-879a-e4a49ca6144c', type: 'pokemon' }
       }
     }
   }

--- a/src/data/points/2020/05.data.ts
+++ b/src/data/points/2020/05.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_5:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/06.data.ts
+++ b/src/data/points/2020/06.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_6:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/08.data.ts
+++ b/src/data/points/2020/08.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_8:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/09.data.ts
+++ b/src/data/points/2020/09.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_9:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/10.data.ts
+++ b/src/data/points/2020/10.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_10:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/12.data.ts
+++ b/src/data/points/2020/12.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_12:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/14.data.ts
+++ b/src/data/points/2020/14.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_14:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/15.data.ts
+++ b/src/data/points/2020/15.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_15:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/16.data.ts
+++ b/src/data/points/2020/16.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_16:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/18.data.ts
+++ b/src/data/points/2020/18.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_18:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/19.data.ts
+++ b/src/data/points/2020/19.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_19:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/21.data.ts
+++ b/src/data/points/2020/21.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_21:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/22.data.ts
+++ b/src/data/points/2020/22.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_22:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/23.data.ts
+++ b/src/data/points/2020/23.data.ts
@@ -39,7 +39,7 @@ export const pointsData2020_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2020/26.data.ts
+++ b/src/data/points/2020/26.data.ts
@@ -167,7 +167,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Tentacool remove
+          id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -195,7 +199,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Woobat remove
+          id: '90e005cf-a344-477c-974d-a7b9c4888ddb',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -223,7 +231,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Slowpoke remove
+          id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -251,7 +263,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Torchic remove
+          id: 'da4d8b9a-edbc-4521-a783-ce83551a912e',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -279,7 +295,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Eevee remove
+          id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -307,7 +327,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Snover remove
+          id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -335,7 +359,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Abomasnow remove
+          id: '1ca9d7e2-e4e6-4080-92cc-8751529f4d87',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -363,7 +391,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Regice remove
+          id: 'bc9d6986-f768-4988-a37c-f7437709c9d8',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -391,7 +423,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Snorunt remove
+          id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -419,7 +455,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Cubchoo remove
+          id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -447,7 +487,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Delibird remove
+          id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -475,7 +519,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Skarmory remove
+          id: '60aa4fc8-6cd1-47f3-af8e-480c7a7c28ff',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -503,7 +551,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Beartic remove
+          id: 'a1bb598f-7991-4bfe-b0c1-da273b4304bb',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -531,7 +583,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Registeel remove
+          id: 'dd83ad95-5524-4d5c-9a9b-dce9210777b0',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -559,7 +615,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Swanna remove
+          id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -587,7 +647,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58', type: 'pokemon' }
+        data: {
+          // Cubchoo remove
+          id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -615,7 +679,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Oricorio remove
+          id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -643,7 +711,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Oricorio remove
+          id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -671,7 +743,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Oricorio remove
+          id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -699,7 +775,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Oricorio remove
+          id: 'ded7e96b-b368-4269-aeb9-22934ffe30c9',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -727,7 +807,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Flabébé remove
+          id: 'd750fb34-d294-4862-9c8d-8d04a72570a1',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -755,7 +839,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Floette remove
+          id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -783,7 +871,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Florges remove
+          id: '60cbac1b-57e8-40af-8489-34c92c1c358b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -811,7 +903,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Elgyem remove
+          id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -839,7 +935,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '0e7e4c84-f130-46d1-bb9d-946f829e20ad', type: 'pokemon' }
+        data: {
+          // Snorunt remove
+          id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -867,7 +967,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Wooloo remove
+          id: '82296f48-2914-4e67-8538-8b9c68158cd2',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -895,7 +999,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Dubwool remove
+          id: '7ca0dfe1-0af3-4a55-b38a-7f6ec0466432',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -923,7 +1031,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Drapion remove
+          id: 'f8a1d155-1048-4d0a-b977-028d056fde1b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -951,7 +1063,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Nuzleaf remove
+          id: '986c888a-af44-475a-b4c0-98ae73d9c48d',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -979,7 +1095,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Magcargo remove
+          id: '26ed7ddd-adce-4e8b-9036-942fe295b8ae',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1007,7 +1127,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Munna remove
+          id: '7bf836b2-54e2-456b-9239-08f496fece30',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1035,7 +1159,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Musharna remove
+          id: '48d09eed-1a6a-4faa-b2ce-7b5438e3606c',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1063,7 +1191,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Scraggy remove
+          id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1091,7 +1223,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Blipbug remove
+          id: '5da2230d-4843-47e8-8ac0-f877f1814a58',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1119,7 +1255,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Venipede remove
+          id: 'aef1ff76-200a-4e31-b4fb-eb1d5815a3c7',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1147,7 +1287,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Karrablast remove
+          id: 'ea5c17dc-4c66-4ccf-96f7-d7de64844bac',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1175,7 +1319,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Nincada remove
+          id: 'af56cc6b-3a28-4867-a156-2345080173ec',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1203,7 +1351,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Ninjask remove
+          id: '26c3c20a-6d0d-474d-8e84-54a8889b4ec2',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1231,7 +1383,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Shedinja remove
+          id: '91299325-9853-42fe-9042-3d293409638d',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1259,7 +1415,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Barbaracle remove
+          id: '382c0c1b-2a77-4d7c-bed3-78aa53adb6b6',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1287,7 +1447,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '82296f48-2914-4e67-8538-8b9c68158cd2', type: 'pokemon' }
+        data: {
+          // Audino remove
+          id: '93e005fa-ae64-4232-8cd7-898d5b46a827',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1315,7 +1479,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Stantler remove
+          id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1343,7 +1511,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Litwick remove
+          id: 'e4b4cdf9-bc1a-426e-845f-9346d3346b71',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1371,7 +1543,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Smoochum remove
+          id: 'fe4377b2-be91-4308-9401-9d337624ad45',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1399,7 +1575,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Rotom remove
+          id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1427,7 +1607,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Vulpix (Alolan) remove
+          id: '85969679-9e0c-459a-a9aa-4b7cbcebedce',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1455,7 +1639,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '6931874b-a4ce-4abb-a16c-c6183a1668ab', type: 'pokemon' }
+        data: {
+          // Ninetales (Alolan) remove
+          id: 'fac6c3a8-996e-49ed-ba3e-50b028e169ef',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1483,7 +1671,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       pokemon: {
-        data: { id: '3a3d7a26-b94e-49e6-98d7-3d4ba82fb7da', type: 'pokemon' }
+        data: {
+          // Cubchoo remove
+          id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1511,7 +1703,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       pokemon: {
-        data: { id: '3a3d7a26-b94e-49e6-98d7-3d4ba82fb7da', type: 'pokemon' }
+        data: {
+          // Seel remove
+          id: '3a3d7a26-b94e-49e6-98d7-3d4ba82fb7da',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1539,7 +1735,11 @@ export const pointsData2020_26:IPointEntities = {
         data: { id: 'cfedba07-3cbe-4825-8c40-8623c2b89e31', type: 'player' }
       },
       pokemon: {
-        data: { id: '3a3d7a26-b94e-49e6-98d7-3d4ba82fb7da', type: 'pokemon' }
+        data: {
+          // Snover remove
+          id: 'fd2affc4-e41b-418e-a559-62741f95da21',
+          type: 'pokemon'
+        }
       }
     }
   }

--- a/src/data/points/2021/25.data.ts
+++ b/src/data/points/2021/25.data.ts
@@ -55,7 +55,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '2b97a6f9-2db7-4887-9f18-fe13945392a9', type: 'pokemon' }
+        data: {
+          // Kyurem remove
+          id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -83,7 +87,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Charmander remove
+          id: '558462e3-65d4-4440-9617-63fae7d395e8',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -111,7 +119,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Pikachu remove
+          id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -139,7 +151,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Sandshrew (Alolan) remove
+          id: '1dc0b2ae-31d4-4759-9908-28efae57fc79',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -167,7 +183,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Sneasel remove
+          id: '230e56ee-3f9e-4cc5-8b71-f192068fc1cd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -195,7 +215,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Stantler remove
+          id: '6931874b-a4ce-4abb-a16c-c6183a1668ab',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -223,7 +247,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Snorunt remove
+          id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -251,7 +279,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Glalie remove
+          id: 'a4b7fc43-7daa-4a87-bc5c-672f8ba0cf8f',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -279,7 +311,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Spheal remove
+          id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -307,7 +343,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Cubchoo remove
+          id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -335,7 +375,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Reshiram remove
+          id: '9c2bb690-dbf9-441b-9d38-8d4c094b6650',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -363,7 +407,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Zekrom remove
+          id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -391,7 +439,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Kyurem remove
+          id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -419,7 +471,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Shellos remove
+          id: '0091eadb-706c-40d1-ba11-5c95b383b46b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -447,7 +503,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Gastrodon remove
+          id: '92997f39-9ada-469b-a9db-25b0d85bf06a',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -475,7 +535,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Pachirisu remove
+          id: 'b15f85e1-4bb3-41e4-a6eb-0e3ee82a4910',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -503,7 +567,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '3be16e09-d7c4-4ea5-a5bc-8fb3366355b6', type: 'player' }
       },
       pokemon: {
-        data: { id: '558462e3-65d4-4440-9617-63fae7d395e8', type: 'pokemon' }
+        data: {
+          // Buizel remove
+          id: 'dd322a58-8977-4cfd-b028-8df24f401acf',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -531,7 +599,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Palpitoad remove
+          id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -559,7 +631,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Hoppip remove
+          id: '45458f0f-3118-4b87-a148-bee667717bc2',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -587,7 +663,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Mareep remove
+          id: '2d3f45a9-8f6b-4540-9171-037c8a0dac74',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -615,7 +695,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Flaaffy remove
+          id: '0bc1956d-f21f-4b11-ba29-ffcf7c3a2cad',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -643,7 +727,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Caterpie remove
+          id: '2558897e-fbf9-462e-b298-99d41d104263',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -671,7 +759,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Snorunt remove
+          id: 'f95826ab-e534-4503-934c-fb4dd898b6b7',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -699,7 +791,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Spheal remove
+          id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+          type: 'pokemon'
+        }        
       }
     }
   }
@@ -727,7 +823,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Poliwhirl remove
+          id: '59b1749c-2ae8-46f1-8a75-10b29cbb39ac',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -755,7 +855,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Scraggy remove
+          id: '3b77cf43-32e8-4e19-96ec-00a6afd6906f',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -783,7 +887,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Sewaddle remove
+          id: 'dc27c553-3e13-4dc5-b6d6-241335e5f8d9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -811,7 +919,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Swanna remove
+          id: 'f677f96c-df1d-414d-8040-3c286aecc7cd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -839,7 +951,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Charmander remove
+          id: '558462e3-65d4-4440-9617-63fae7d395e8',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -867,7 +983,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '7d054896-a0ea-4368-bff1-856b6abf8419', type: 'player' }
       },
       pokemon: {
-        data: { id: '5d0b4f22-11e3-4e7d-8fd9-e06749d0f90f', type: 'pokemon' }
+        data: {
+          // Ratatta (Alolan) remove
+          id: '1a636f2b-e354-496d-9ae1-07de7d69ec7e',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1091,7 +1211,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '6e1abaf6-8b92-4354-a9f8-1d2f0f0f5b71', type: 'pokemon' }
+        data: {
+          // Sandshrew (Alolan) remove
+          id: '1dc0b2ae-31d4-4759-9908-28efae57fc79',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1119,7 +1243,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: '6e1abaf6-8b92-4354-a9f8-1d2f0f0f5b71', type: 'pokemon' }
+        data: {
+          // Zekrom remove
+          id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1175,7 +1303,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Crabrawler remove
+          id: '97bcb939-d1b2-4541-a03f-ef2b6af51ecf',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1203,7 +1335,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Heliolisk remove
+          id: '6683854f-5c01-4312-acb7-fb7687259b4b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1231,7 +1367,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Kyurem remove
+          id: 'f991c065-2012-4e0e-9b29-ba9d140bebbe',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1259,7 +1399,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Elgyem remove
+          id: '82035b6b-77a1-40d6-9b33-da4de9ba6537',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1287,7 +1431,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Tentacool remove
+          id: 'e97d06b9-8dee-4dc6-a78b-e8949982cc58',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1315,7 +1463,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Zekrom remove
+          id: '2b97a6f9-2db7-4887-9f18-fe13945392a9',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1343,7 +1495,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'a3abfccd-9cb0-422a-b3f3-aceb26f8b678', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Pidove remove
+          id: '20c0062a-e0b2-4bf5-ae0c-ac4b142c1c54',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1399,7 +1555,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d', type: 'player' }
       },
       pokemon: {
-        data: { id: '1dc0b2ae-31d4-4759-9908-28efae57fc79', type: 'pokemon' }
+        data: {
+          // Corphish remove
+          id: '5fd6660f-f631-41eb-a4c9-a437e062417c',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1427,7 +1587,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d', type: 'player' }
       },
       pokemon: {
-        data: { id: '1dc0b2ae-31d4-4759-9908-28efae57fc79', type: 'pokemon' }
+        data: {
+          // Psyduck remove
+          id: '0fee26f0-8367-4d19-a22c-dd1bbf6dc400',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1455,7 +1619,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d', type: 'player' }
       },
       pokemon: {
-        data: { id: '1dc0b2ae-31d4-4759-9908-28efae57fc79', type: 'pokemon' }
+        data: {
+          // Spheal remove
+          id: '63e50f1c-ae9d-4b7b-932d-17f9bafee222',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1483,7 +1651,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d', type: 'player' }
       },
       pokemon: {
-        data: { id: '1dc0b2ae-31d4-4759-9908-28efae57fc79', type: 'pokemon' }
+        data: {
+          // Cubchoo remove
+          id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1539,7 +1711,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'e6f1bc63-842c-4927-afc8-65195e80300b', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Pikachu remove
+          id: '230abe97-6933-45e0-b351-d8bd2e7c0543',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1567,7 +1743,11 @@ export const pointsData2021_25:IPointEntities = {
         data: { id: 'e6f1bc63-842c-4927-afc8-65195e80300b', type: 'player' }
       },
       pokemon: {
-        data: { id: '9219d4f4-2bd8-4568-a1d0-1f4f12fe6cbd', type: 'pokemon' }
+        data: {
+          // Wurmple remove
+          id: 'c36f780b-5769-407b-9600-921d57ace904',
+          type: 'pokemon'
+        }
       }
     }
   }

--- a/src/data/points/2022/19.data.ts
+++ b/src/data/points/2022/19.data.ts
@@ -11,7 +11,7 @@ export const pointsData2022_19:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2022/20.data.ts
+++ b/src/data/points/2022/20.data.ts
@@ -11,7 +11,7 @@ export const pointsData2022_20:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2022/22.data.ts
+++ b/src/data/points/2022/22.data.ts
@@ -11,7 +11,7 @@ export const pointsData2022_22:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true

--- a/src/data/points/2022/23.data.ts
+++ b/src/data/points/2022/23.data.ts
@@ -11,7 +11,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -39,7 +39,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -67,7 +67,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -95,7 +95,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -123,7 +123,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -151,7 +151,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -179,7 +179,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -207,7 +207,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -235,7 +235,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -263,7 +263,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -291,7 +291,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -319,7 +319,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -347,7 +347,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -375,7 +375,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -403,7 +403,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -431,7 +431,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -459,7 +459,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -487,7 +487,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -515,7 +515,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -543,7 +543,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -571,7 +571,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -599,7 +599,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -627,7 +627,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -655,7 +655,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -683,7 +683,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -711,7 +711,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -739,7 +739,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -767,7 +767,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -795,7 +795,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -823,7 +823,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -851,7 +851,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -879,7 +879,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -907,7 +907,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -935,7 +935,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -963,7 +963,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -991,7 +991,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1019,7 +1019,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1047,7 +1047,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1075,7 +1075,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1103,7 +1103,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1131,7 +1131,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1159,7 +1159,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1187,7 +1187,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1215,7 +1215,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1243,7 +1243,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1271,7 +1271,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1299,7 +1299,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1327,7 +1327,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1355,7 +1355,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1383,7 +1383,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1411,7 +1411,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1439,7 +1439,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1467,7 +1467,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1495,7 +1495,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1523,7 +1523,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1551,7 +1551,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1579,7 +1579,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1607,7 +1607,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1635,7 +1635,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1663,7 +1663,7 @@ export const pointsData2022_23:IPointEntities = {
     attributes: {
       ball: null,
       catchDate: null,
-      firstCatch: true,
+      firstCatch: false,
       game: null,
       method: null,
       oldSystemPoint: true
@@ -1707,7 +1707,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Tadbulb remove
+          id: 'f524419c-0643-4277-a890-a0901271dd4b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1735,7 +1739,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Magnezone remove
+          id: '4e822cc9-7022-464f-aecd-e88716ad4943',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1763,7 +1771,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Charcadet remove
+          id: 'cf3736c5-0795-49e3-b1e0-bb464936465d',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1791,7 +1803,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Pawmot remove
+          id: 'c5ee9920-eaae-4713-93f4-2586a68b4f84',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1819,7 +1835,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Pawmo remove
+          id: '17441171-60a5-4dc8-b993-15c9101f8143',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1847,7 +1867,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Pawmi remove
+          id: '73f482cc-0ea4-4c43-bd42-43ad868cf90a',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1875,7 +1899,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Bellibolt remove
+          id: '7d2e460b-6d0d-4bab-88c8-b45ef086049b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1903,7 +1931,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Frigibax remove
+          id: '9f8c7a79-1fcc-4c5c-95b5-a6e49d170c5b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1931,7 +1963,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Drednaw remove
+          id: '112a03cb-fe37-4aa4-9b7a-920a8b246339',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1959,7 +1995,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Chewtle remove
+          id: 'dbed930c-3262-4fff-afca-dd52d4a02bd6',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -1987,7 +2027,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Ceruledge remove
+          id: 'adf10d91-040a-4dad-87c1-d8e66259ad30',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2015,7 +2059,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Armarouge remove
+          id: 'd54d9dc3-e2be-4e94-92fe-ef99ccfcc073',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2043,7 +2091,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Makuhita remove
+          id: '40d7919e-766c-4109-a5d1-82444c0b63ed',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2071,7 +2123,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Toedscool remove
+          id: '6b57b43b-60e3-44e8-b740-0635e8e899ab',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2099,7 +2155,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Pyroar remove
+          id: 'bad0a7ce-7718-40d9-8b65-5a43b397794b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2127,7 +2187,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Litleo remove
+          id: '283dccaf-97bb-446f-997b-5b74b380a626',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2155,7 +2219,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Mareanie remove
+          id: '77f390a4-0d38-434e-af28-8c858e060b3c',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2183,7 +2251,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Pelipper remove
+          id: '8d36fc6e-c19c-41de-a990-02e218113832',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2211,7 +2283,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Wingull remove
+          id: 'e50b840e-2e3f-4ace-971e-b76e332b1857',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2239,7 +2315,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Dondozo remove
+          id: 'eede505c-d4c0-41a8-93c2-34ec4913ad3b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2267,7 +2347,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Skiddo remove
+          id: '8a099e42-ba65-4365-90d9-2a2bb4966efc',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2295,7 +2379,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Sinistea remove
+          id: '68847ddd-c418-47b7-ba3a-404f1db5caf2',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2323,7 +2411,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Komala remove
+          id: '360c0865-0bfc-46dd-807d-2532ddfab4dd',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2351,7 +2443,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Klawf remove
+          id: '454e6e19-6c37-44d9-9bb5-c6051c76ffbc',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2379,7 +2475,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Slowbro remove
+          id: '24e010f3-7f1e-49c0-a63f-5e1605d5b8ff',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2407,7 +2507,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Slowpoke remove
+          id: '7aeb9b9c-e12f-4729-bad4-708476bf0a5b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2435,7 +2539,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Annihilape remove
+          id: '8833b9a4-399e-4a43-a864-3e1b0393fd01',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2463,7 +2571,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Mankey remove
+          id: 'e07a9ffb-7f01-4691-a8c0-a05aabbedb20',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2491,7 +2603,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Hippopotas remove
+          id: '1a0682c6-6045-4a09-8ced-17c4a60211b0',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2519,7 +2635,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Growlithe remove
+          id: 'ceabbc48-23a8-45a8-be14-959184bfbb0b',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2547,7 +2667,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Polteageist remove
+          id: '8f964492-a6ad-4157-991c-abd964de54d3',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2575,7 +2699,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Cyclizar remove
+          id: 'c14ee623-1853-4da3-9021-f55805c1bc71',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2603,7 +2731,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Sandile remove
+          id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2631,7 +2763,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Volcarona remove
+          id: '149043bb-0730-4320-bdc6-fa219e308223',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2659,7 +2795,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Larvesta remove
+          id: 'f3f2667e-99f3-4b9f-ba31-61c03aceb378',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2687,7 +2827,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Hoppip remove
+          id: '45458f0f-3118-4b87-a148-bee667717bc2',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2715,7 +2859,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Avalugg remove
+          id: '06e87530-bdd5-41cd-8a70-197d8f70035a',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -2743,7 +2891,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: 'ec689f25-fffe-4249-b89d-603d574bacee', type: 'player' }
       },
       pokemon: {
-        data: { id: 'f524419c-0643-4277-a890-a0901271dd4b', type: 'pokemon' }
+        data: {
+          // Makuhita remove
+          id: '40d7919e-766c-4109-a5d1-82444c0b63ed',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4535,7 +4687,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Bergmite remove
+          id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4563,7 +4719,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Avalugg remove
+          id: '06e87530-bdd5-41cd-8a70-197d8f70035a',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4591,7 +4751,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Delibird remove
+          id: '3852ccba-90fe-496f-91dd-f1f104d7a0e8',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4619,7 +4783,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Scream Tail remove
+          id: '191d3a48-0697-4a8c-9f20-25d0de2e1e05',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4647,7 +4815,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Eevee remove
+          id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4675,7 +4847,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // Pidgey remove
+          id: '9d2eb67b-06bb-41a3-936c-654a2fa1e475',
+          type: 'pokemon'
+        }
       }
     }
   }
@@ -4703,7 +4879,11 @@ export const pointsData2022_23:IPointEntities = {
         data: { id: '3657e524-63a2-4eb6-b768-c20b104e41a1', type: 'player' }
       },
       pokemon: {
-        data: { id: '05b64ab2-3b50-4730-800d-48a8d9b1e5cb', type: 'pokemon' }
+        data: {
+          // MissingNo remove
+          id: 'f77b6663-537d-469c-bd2f-0e4347bb5ca3',
+          type: 'pokemon'
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request updates point data for 2017-2022 to ensure there is only 1 winner per competition and that free-for-alls have the proper pokemon per point.  I also manually went through each competition to make validate the data as based on the below spreadsheet.  In addition, this pull request tries to specify as many valid pokemon as are available from the spreadsheet (or linked from the spreadsheet).  This implicitly updates the trivia page for more accurate data.

https://docs.google.com/spreadsheets/d/1wgp9pUMUkJeUD-Dv1OlOlc7Hw8Fa9T--kggVaYHKMU8/edit?gid=1233192627#gid=1233192627
