### PR TITLE
Properly handle '-' in the parser and fix a few typos

### DIFF
--- a/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.ts
+++ b/src/app/components/admin/pokemon-list-generator/pokemon-list-generator.component.ts
@@ -46,7 +46,7 @@ export class PokemonListGeneratorComponent {
 
 
   parse(parsedPokemon : ParsedPokemon) : void {
-    const normalizedText = parsedPokemon.text.replace(/[^a-zA-Z\s♀♂().-\\']/g,'').trim().toLowerCase();
+    const normalizedText = parsedPokemon.text.replace(/[^a-zA-Z\s♀♂().\-\\']/g,'').trim().toLowerCase();
     if (!normalizedText) {
       return;
     }

--- a/src/data/pokemon/regionals.data.ts
+++ b/src/data/pokemon/regionals.data.ts
@@ -7,7 +7,7 @@ export const pokemonDataRegionals:IPokemonEntities = {
       'id': '1a636f2b-e354-496d-9ae1-07de7d69ec7e',
       'type': 'pokemon' as 'pokemon',
       'attributes': {
-        'name': 'Ratatta (Alolan)',
+        'name': 'Rattata (Alolan)',
         'generation': 7,
         'dexNo': '0019',
         'forme': 'alolan'
@@ -260,7 +260,7 @@ export const pokemonDataRegionals:IPokemonEntities = {
       'id': 'b6af61b9-ea70-4cd5-9c39-b901a94ced0c',
       'type': 'pokemon' as 'pokemon',
       'attributes': {
-        'name': 'Farfetch’d (Galarian)',
+        'name': 'Farfetch\'d (Galarian)',
         'generation': 8,
         'dexNo': '0083',
         'forme': 'galarian'


### PR DESCRIPTION
The bulk import parser was treating the '-' character as a range instead of matching the character itself.  This pull fixes that.  Also fixes some typos in pokemon data.