### PR TITLE
Add "We are the Champions" competition points for April 2026

### DIFF
--- a/src/data/players.data.ts
+++ b/src/data/players.data.ts
@@ -1057,4 +1057,15 @@ export const playersData: IPlayerEntities = {
       },
     },
   },
+  // Silent0123 (@Silent0123)
+  '6703130b-8728-490b-87dc-d66e097583d5': {
+    data: {
+      type: 'player' as 'player',
+      id: '6703130b-8728-490b-87dc-d66e097583d5',
+      attributes: {
+        realName: 'Silent0123',
+        displayName: 'Silent0123',
+      },
+    },
+  },
 };

--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -39,4 +39,277 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Tone (@Tone)
+  //  0067. Machoke
+  'e8eb8ac3-6384-4553-98c1-15b55ef4c19c': {
+    data: {
+      id: 'e8eb8ac3-6384-4553-98c1-15b55ef4c19c',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '1737b066-12bc-4df4-9041-8e62872058d8',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Silent0123 (@Silent0123)
+  //  0478. Froslass
+  '71bef6bc-00b5-4a1f-90f9-0d986a67fa08': {
+    data: {
+      id: '71bef6bc-00b5-4a1f-90f9-0d986a67fa08',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6703130b-8728-490b-87dc-d66e097583d5',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'a560acfd-f044-4804-a740-7479789f9bd7',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Silent0123 (@Silent0123)
+  //  0697. Tyrantrum
+  '56196f53-25ec-4139-b7e0-b644093800e6': {
+    data: {
+      id: '56196f53-25ec-4139-b7e0-b644093800e6',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6703130b-8728-490b-87dc-d66e097583d5',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'a7ef88e6-4210-4945-af65-362480932825',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Philip Starns (@Philip Starns)
+  //  0551. Sandile
+  'd88c3288-1c82-40f4-81aa-9729aa152fb4': {
+    data: {
+      id: 'd88c3288-1c82-40f4-81aa-9729aa152fb4',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: 'e7e5548f-6d09-421f-8f37-966949fe41b9',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'fbd0d149-dbbe-4a22-a970-5821cb900ccc',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Tone (@Tone)
+  //  0479. Rotom
+  'fda01557-8144-410a-a11b-c59858d88dbf': {
+    data: {
+      id: 'fda01557-8144-410a-a11b-c59858d88dbf',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '4e276445-bb68-41ef-9de2-4bd0bd7a6f0c',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Sean G (@lostlemon)
+  //  0924. Tandemaus
+  '0908606e-b060-443a-99a2-f431e103d7e3': {
+    data: {
+      id: '0908606e-b060-443a-99a2-f431e103d7e3',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'f4124e83-411f-4391-84b8-8816a6716f69',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Sean G (@lostlemon)
+  //  0935. Charcadet
+  '7cd68842-2423-4869-9db2-4b55b17f3d8d': {
+    data: {
+      id: '7cd68842-2423-4869-9db2-4b55b17f3d8d',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'cf3736c5-0795-49e3-b1e0-bb464936465d',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
This PR adds 7 new point entries for the "We are the Champions" competition (April 12-25, 2026) and registers a new player in the system.

## Key Changes
- **Points Data (August 2026 file)**: Added 7 new point entries for the "We are the Champions" competition:
  - Machoke (Tone)
  - Froslass (Silent0123)
  - Tyrantrum (Silent0123)
  - Sandile (Philip Starns)
  - Rotom (Tone)
  - Tandemaus (Sean G / lostlemon)
  - Charcadet (Sean G / lostlemon)

- **Players Data**: Registered new player Silent0123 with ID `6703130b-8728-490b-87dc-d66e097583d5`

## Implementation Details
- All points are dated April 13, 2026 (catch date)
- Each point has a value of 1 and is not marked as a first catch
- All entries reference the same competition ID: `6c77db3f-9ccf-4c42-b0e2-8860f561ca7b`
- Points are stored in the August 2026 data file following the existing data structure pattern

https://claude.ai/code/session_01HoGsmY9anhtfoyDBfe8gfk