### PR TITLE
Add Charmander catch record for Morgan in We are the Champions

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -388,4 +388,42 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Morgan (Leaf) (@Leaf)
+  //  0004. Charmander
+  '8dd3adbc-d125-480e-a7e0-6e68a7042d1c': {
+    data: {
+      id: '8dd3adbc-d125-480e-a7e0-6e68a7042d1c',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-15',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: 'fa7f7600-5379-4166-8e3f-5ccfe683bd91',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '558462e3-65d4-4440-9617-63fae7d395e8',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a new point entry to the August 2026 points data, recording a Pokémon catch during the "We are the Champions" competition.

## Key Changes
- Added a new point record for player Morgan (Leaf) catching Charmander during the "We are the Champions" competition (April 12-25, 2026)
- Catch date: April 15, 2026
- Point value: 1
- This is not a first catch and was not caught using the old system

## Implementation Details
- Entry ID: `8dd3adbc-d125-480e-a7e0-6e68a7042d1c`
- Competition ID: `6c77db3f-9ccf-4c42-b0e2-8860f561ca7b`
- Player ID: `fa7f7600-5379-4166-8e3f-5ccfe683bd91`
- Pokémon ID: `558462e3-65d4-4440-9617-63fae7d395e8` (Charmander)
- No associated ball, game, or catch method recorded

https://claude.ai/code/session_017dHt289HE2PVeD6ywAXV5V