### PR TITLE
Add Castform catch record for We are the Champions event

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -426,4 +426,42 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Sean G (@lostlemon)
+  //  0351. Castform
+  'e6dfd5a7-bb60-42f5-b404-4a3325792749': {
+    data: {
+      id: 'e6dfd5a7-bb60-42f5-b404-4a3325792749',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-15',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '638589a0-9404-460e-bd21-05469e268d6b',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a new point entry for a Castform catch during the "We are the Champions" competition event (April 12-25, 2026).

## Changes
- Added point record for Castform (Pokédex #351) caught on April 15, 2026
- Assigned to player Sean G (@lostlemon)
- Linked to "We are the Champions" competition
- Recorded as a standard 1-point catch (not a first catch, no special ball or method)

## Details
- **Catch Date**: April 15, 2026
- **Competition**: We are the Champions (6c77db3f-9ccf-4c42-b0e2-8860f561ca7b)
- **Player**: 0e59368f-37ea-44c9-bc7a-8ce047a1447f
- **Pokémon**: Castform (638589a0-9404-460e-bd21-05469e268d6b)
- **Points**: 1

https://claude.ai/code/session_013aQu9mDUnndZp3gr5LnTaD