### PR TITLE
Add Honedge catch record for We are the Champions competition

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -735,4 +735,43 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Tone (@Tone)
+  //  0679. Honedge
+  'f40f91c7-7d2b-4a27-a2d4-860569263949': {
+    data: {
+      id: 'f40f91c7-7d2b-4a27-a2d4-860569263949',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-21',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '0633d25c-8f26-4049-8403-407ff49b7a1d',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a new point entry for a Pokémon catch during the "We are the Champions" competition event (April 12-25, 2026).

## Changes
- Added a new point record for player Tone's Honedge catch
  - Catch date: April 21, 2026
  - Competition: "We are the Champions" (6c77db3f-9ccf-4c42-b0e2-8860f561ca7b)
  - Pokémon: Honedge (0633d25c-8f26-4049-8403-407ff49b7a1d)
  - Point value: 1
  - Not a first catch, no specific ball/game/method recorded

## Details
This entry follows the existing data structure for point records in the August 2026 dataset, with all required relationships properly configured (competition, player, and pokémon references).

https://claude.ai/code/session_01J93kHQHvUy8nTg6x96Zg6g