### PR TITLE
Add Poltchageist and Kirlia catches for Deathrite in We are the Champions

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -774,4 +774,82 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Deathrite (@Deathrite)
+  //  1012. Poltchageist
+  '4cbd004f-9173-4cfd-ad14-a566f93a17fe': {
+    data: {
+      id: '4cbd004f-9173-4cfd-ad14-a566f93a17fe',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-21',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '2123e057-079c-42d2-b9d6-a15dfef99a51',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '1e1957a8-49bd-49e6-ab63-0ce298dabaca',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Deathrite (@Deathrite)
+  //  0281. Kirlia
+  '7c325b85-c465-4a8b-af3a-7a3427a88051': {
+    data: {
+      id: '7c325b85-c465-4a8b-af3a-7a3427a88051',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-21',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '2123e057-079c-42d2-b9d6-a15dfef99a51',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '0691d3ef-a4d8-4974-8065-413757871b80',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added two new point entries for the "We are the Champions" competition (April 12-25, 2026) to record Pokémon catches by player Deathrite.

## Changes
- Added point entry for **Poltchageist** (1012) caught on 2026-04-21
- Added point entry for **Kirlia** (0281) caught on 2026-04-21
- Both entries are associated with the "We are the Champions" competition and award 1 point each
- Both catches are marked as non-first catches with no specific ball or method recorded

## Details
- Competition ID: `6c77db3f-9ccf-4c42-b0e2-8860f561ca7b`
- Player ID: `2123e057-079c-42d2-b9d6-a15dfef99a51` (Deathrite)
- Catch date: April 21, 2026
- Point value: 1 each

https://claude.ai/code/session_013uzTzRmNxf6P8b5vDSnf1Z