### PR TITLE
Add Swablu catch data for We are the Champions competition

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -969,4 +969,43 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Tone (@Tone)
+  //  0333. Swablu
+  '7d030057-d521-4500-a262-081d397409a8': {
+    data: {
+      id: '7d030057-d521-4500-a262-081d397409a8',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-23',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '6b7a4cdb-fd7b-448c-9f03-2b49b4ab3b9d',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '9c6a7a1e-296d-447e-9293-713645a435bf',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a new point entry for a Swablu caught during the "We are the Champions" competition event (April 12-25, 2026).

## Changes
- Added point record for player Tone's Swablu catch on April 23, 2026
- Pokémon: Swablu (National Dex #0333)
- Competition: "We are the Champions" (April 12-25, 2026)
- Point value: 1
- Marked as non-first catch and not from old system

## Details
- Catch date: April 23, 2026
- No associated ball, game, or method data
- Linked to existing competition, player, and Pokémon entities via their respective IDs

https://claude.ai/code/session_014718Lc5oP4GWjndwrM1wQE