### PR TITLE
Add Panpour point for Lewthelegend

### DIFF
--- a/src/data/points/2026/08.data.ts
+++ b/src/data/points/2026/08.data.ts
@@ -1163,4 +1163,42 @@ export const pointsData2026_08: IPointEntities = {
       },
     },
   },
+  //  We are the Champions 12 Apr 2026 to 25 Apr 2026
+  //  Lewis Dobie (@Lewthelegend)
+  //  0515. Panpour
+  '28e31295-ec0a-4959-b7bb-5f8237820b52': {
+    data: {
+      id: '28e31295-ec0a-4959-b7bb-5f8237820b52',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-04-20',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '6c77db3f-9ccf-4c42-b0e2-8860f561ca7b',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '7d054896-a0ea-4368-bff1-856b6abf8419',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'dfd21c51-0564-4745-b017-61b1733962b9',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
Lewis Dobie caught Panpour on 2026-04-20 during the
"We are the Champions" competition (12 Apr - 25 Apr 2026).
Panpour's evolution Simipour is in the validPokemon list.