### PR TITLE
Add Cacnea catch record for Pokopia competition (May 7, 2026)

### DIFF
--- a/src/data/points/2026/09.data.ts
+++ b/src/data/points/2026/09.data.ts
@@ -613,4 +613,43 @@ export const pointsData2026_09: IPointEntities = {
       },
     },
   },
+
+  //  Pokopia 26 Apr 2026 to 9 May 2026
+  //  Philip Starns (@Philip Starns)
+  //  0331. Cacnea
+  '0ef53faf-dd02-4f3f-93f1-0a230073efab': {
+    data: {
+      id: '0ef53faf-dd02-4f3f-93f1-0a230073efab',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-05-07',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '77546964-8743-4092-9de8-4f84823adc2d',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: 'e7e5548f-6d09-421f-8f37-966949fe41b9',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '40ae3055-bca5-4c88-9313-34b563d7e8cc',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a new Pokémon catch record to the September 2026 points data file for the Pokopia competition.

## Changes
- Added a new point entry for a Cacnea (Pokédex #0331) caught on May 7, 2026 during the Pokopia competition (April 26 - May 9, 2026)
- Recorded by player Philip Starns
- Entry includes:
  - Catch date: May 7, 2026
  - Point value: 1
  - Not a first catch
  - No specific ball, game, or method recorded
  - Linked to competition ID: `77546964-8743-4092-9de8-4f84823adc2d`
  - Linked to player ID: `e7e5548f-6d09-421f-8f37-966949fe41b9`
  - Linked to Pokémon ID: `40ae3055-bca5-4c88-9313-34b563d7e8cc`

https://claude.ai/code/session_01E12gkZyk7sxF7SoBxiRguP