### PR TITLE
Add Bug Hunting Competition 7 point for Combee

### DIFF
--- a/src/data/points/2026/12.data.ts
+++ b/src/data/points/2026/12.data.ts
@@ -388,4 +388,43 @@ export const pointsData2026_12: IPointEntities = {
       },
     },
   },
+
+  //  Bug Hunting Competition 7 Jun 2026 to 20 Jun 2026
+  //  Philip Starns (@Philip Starns)
+  //  0415. Combee
+  '065181e6-57d8-419d-b6f2-23df65ac8bc3': {
+    data: {
+      id: '065181e6-57d8-419d-b6f2-23df65ac8bc3',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-13',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: 'cd955abc-9d99-46db-9512-b48e11fd5988',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: 'e7e5548f-6d09-421f-8f37-966949fe41b9',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '1d583683-c220-41fd-9175-281a26207a83',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a competition point entry for the Bug Hunting Competition (7 Jun 2026 to 20 Jun 2026).

## Changes
- Added point entry for Philip Starns catching Combee (#0415) on 2026-06-13
- Entry ID: `065181e6-57d8-419d-b6f2-23df65ac8bc3`
- Competition ID: `cd955abc-9d99-46db-9512-b48e11fd5988`
- Player ID: `e7e5548f-6d09-421f-8f37-966949fe41b9`
- Pokemon ID: `1d583683-c220-41fd-9175-281a26207a83`
- `firstCatch` set to `false` (existing entries already have first catch recorded)

https://claude.ai/code/session_017TYjUVodoG3zNGH97PsUBP