### PR TITLE
Add Tick Tick BOOM! competition points for Sean G

### DIFF
--- a/src/data/points/2026/13.data.ts
+++ b/src/data/points/2026/13.data.ts
@@ -39,4 +39,232 @@ export const pointsData2026_13: IPointEntities = {
       },
     },
   },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0109. Koffing
+  '4c781043-fcc6-4219-a3af-344f9ab6bdc7': {
+    data: {
+      id: '4c781043-fcc6-4219-a3af-344f9ab6bdc7',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0109. Koffing
+  'f5d2b102-6a41-419d-a2ba-ae7c418c87cb': {
+    data: {
+      id: 'f5d2b102-6a41-419d-a2ba-ae7c418c87cb',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '6cbfb9db-915f-4874-879a-e4a49ca6144c',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0074. Geodude
+  'c2c5714b-22ba-41a9-9bf8-f777841024d9': {
+    data: {
+      id: 'c2c5714b-22ba-41a9-9bf8-f777841024d9',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0074. Geodude
+  '9eb039ff-364c-420f-b53f-2ff6ea024742': {
+    data: {
+      id: '9eb039ff-364c-420f-b53f-2ff6ea024742',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0074. Geodude
+  'f4d61391-652f-4824-b7e9-5af09550aaa8': {
+    data: {
+      id: 'f4d61391-652f-4824-b7e9-5af09550aaa8',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'fad511fd-a126-4a39-b926-b3b519343992',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+  //  Tick Tick BOOM! 21 Jun 2026 to 4 Jul 2026
+  //  Sean G (@lostlemon)
+  //  0375. Metang
+  '98cbb519-9fee-4f23-a2f7-59e798fa3a46': {
+    data: {
+      id: '98cbb519-9fee-4f23-a2f7-59e798fa3a46',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-06-24',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '76b12b25-0dfa-4838-8b1e-c9d65bf10b48',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '92ceeed3-7543-4241-9a5f-eac4f97fbb75',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added 5 point entries for the "Tick Tick BOOM!" competition (21 Jun 2026 to 4 Jul 2026) caught by Sean G (@lostlemon) on 2026-06-24.

## Changes
- Added 2 Koffing (0109) catches
- Added 3 Geodude (0074) catches
- Added 1 Metang (0375) catch

All entries are standard 1-point catches with `firstCatch: false` and no ball/game/method data.

https://claude.ai/code/session_011p5BRoLMGyTLAzAiNxt6Vq