### PR TITLE
Add PoGo-versary Eevee catch for Christopher (2026-07-06)

### DIFF
--- a/src/data/points/2026/14.data.ts
+++ b/src/data/points/2026/14.data.ts
@@ -191,4 +191,42 @@ export const pointsData2026_14: IPointEntities = {
       },
     },
   },
+  //  PoGo-versary 5 Jul 2026 to 18 Jul 2026
+  //  Christopher (@Christopher)
+  //  0133. Eevee
+  'bc17d0de-2ead-43fe-b96e-0bceba1b7f9e': {
+    data: {
+      id: 'bc17d0de-2ead-43fe-b96e-0bceba1b7f9e',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-07-06',
+        firstCatch: false,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: '80e74992-cb80-418c-a744-c44d276c3f32',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '264f7da7-e6d0-4a18-a216-df7233d13260',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: 'b5ad7979-4d15-453e-b1a0-a4fcf1ba0120',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
Added a point entry for Christopher's Eevee catch during the PoGo-versary 5 competition (5 Jul 2026 to 18 Jul 2026).

## Changes
- Added new point entry to `src/data/points/2026/14.data.ts`
  - Pokemon: Eevee (#0133)
  - Catch date: 2026-07-06
  - Player: Christopher
  - Competition: PoGo-versary 5
  - firstCatch: false (not the first catch in this competition)

https://claude.ai/code/session_013nBA6pp5GAiJkb3TCJ5TdX