### PR TITLE
Format pokemon data with quoted keys and trailing commas

### DIFF
--- a/src/data/pokemon/gen9.data.ts
+++ b/src/data/pokemon/gen9.data.ts
@@ -1,1324 +1,1324 @@
 import { IPokemonEntities } from 'store/reducers/pokemon.reducer';
 
-export const pokemonDataGen9: IPokemonEntities = {
+export const pokemonDataGen9:IPokemonEntities = {
   'd2afec9f-2011-4679-ae35-b024aa418958': {
-    data: {
-      id: 'd2afec9f-2011-4679-ae35-b024aa418958',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Sprigatito',
-        generation: 9,
-        dexNo: '0906',
-      },
-    },
+    'data': {
+      'id': 'd2afec9f-2011-4679-ae35-b024aa418958',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Sprigatito',
+        'generation': 9,
+        'dexNo': '0906'
+      }
+    }
   },
   'f80de2df-3340-4c89-bdcd-afd86b17a19b': {
-    data: {
-      id: 'f80de2df-3340-4c89-bdcd-afd86b17a19b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Floragato',
-        generation: 9,
-        dexNo: '0907',
-      },
-    },
+    'data': {
+      'id': 'f80de2df-3340-4c89-bdcd-afd86b17a19b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Floragato',
+        'generation': 9,
+        'dexNo': '0907'
+      }
+    }
   },
   'd4f284fc-85bb-421c-9db9-6a4b36010be1': {
-    data: {
-      id: 'd4f284fc-85bb-421c-9db9-6a4b36010be1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Meowscarada',
-        generation: 9,
-        dexNo: '0908',
-      },
-    },
+    'data': {
+      'id': 'd4f284fc-85bb-421c-9db9-6a4b36010be1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Meowscarada',
+        'generation': 9,
+        'dexNo': '0908'
+      }
+    }
   },
   '68da5324-8f1b-448a-a4ed-c80b23fcdcbe': {
-    data: {
-      id: '68da5324-8f1b-448a-a4ed-c80b23fcdcbe',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Fuecoco',
-        generation: 9,
-        dexNo: '0909',
-      },
-    },
+    'data': {
+      'id': '68da5324-8f1b-448a-a4ed-c80b23fcdcbe',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Fuecoco',
+        'generation': 9,
+        'dexNo': '0909'
+      }
+    }
   },
   '21a701e6-db00-42e7-9ea1-5638674b7426': {
-    data: {
-      id: '21a701e6-db00-42e7-9ea1-5638674b7426',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Crocalor',
-        generation: 9,
-        dexNo: '0910',
-      },
-    },
+    'data': {
+      'id': '21a701e6-db00-42e7-9ea1-5638674b7426',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Crocalor',
+        'generation': 9,
+        'dexNo': '0910'
+      }
+    }
   },
   '4c23fd0b-6926-4631-a0ca-973f50126a6f': {
-    data: {
-      id: '4c23fd0b-6926-4631-a0ca-973f50126a6f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Skeledirge',
-        generation: 9,
-        dexNo: '0911',
-      },
-    },
+    'data': {
+      'id': '4c23fd0b-6926-4631-a0ca-973f50126a6f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Skeledirge',
+        'generation': 9,
+        'dexNo': '0911'
+      }
+    }
   },
   '8919cdc8-9af8-40c3-9b03-310e2760d7bf': {
-    data: {
-      id: '8919cdc8-9af8-40c3-9b03-310e2760d7bf',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Quaxly',
-        generation: 9,
-        dexNo: '0912',
-      },
-    },
+    'data': {
+      'id': '8919cdc8-9af8-40c3-9b03-310e2760d7bf',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Quaxly',
+        'generation': 9,
+        'dexNo': '0912'
+      }
+    }
   },
   'c657411b-b036-41b5-9726-c1b448ed1619': {
-    data: {
-      id: 'c657411b-b036-41b5-9726-c1b448ed1619',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Quaxwell',
-        generation: 9,
-        dexNo: '0913',
-      },
-    },
+    'data': {
+      'id': 'c657411b-b036-41b5-9726-c1b448ed1619',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Quaxwell',
+        'generation': 9,
+        'dexNo': '0913'
+      }
+    }
   },
   'b8cd0893-7ada-43b7-baa4-7c85d38e6b72': {
-    data: {
-      id: 'b8cd0893-7ada-43b7-baa4-7c85d38e6b72',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Quaquaval',
-        generation: 9,
-        dexNo: '0914',
-      },
-    },
+    'data': {
+      'id': 'b8cd0893-7ada-43b7-baa4-7c85d38e6b72',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Quaquaval',
+        'generation': 9,
+        'dexNo': '0914'
+      }
+    }
   },
   '90a0c67a-ea66-4b05-a603-b1a625e21f64': {
-    data: {
-      id: '90a0c67a-ea66-4b05-a603-b1a625e21f64',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Lechonk',
-        generation: 9,
-        dexNo: '0915',
-      },
-    },
+    'data': {
+      'id': '90a0c67a-ea66-4b05-a603-b1a625e21f64',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Lechonk',
+        'generation': 9,
+        'dexNo': '0915'
+      }
+    }
   },
   'e2ff75ab-d514-4317-99f9-889a1814c6f5': {
-    data: {
-      id: 'e2ff75ab-d514-4317-99f9-889a1814c6f5',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Oinkologne',
-        generation: 9,
-        dexNo: '0916',
-      },
-    },
+    'data': {
+      'id': 'e2ff75ab-d514-4317-99f9-889a1814c6f5',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Oinkologne',
+        'generation': 9,
+        'dexNo': '0916'
+      }
+    }
   },
   'ff315a13-b4dc-4601-aca3-13a16fda7a22': {
-    data: {
-      id: 'ff315a13-b4dc-4601-aca3-13a16fda7a22',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tarountula',
-        generation: 9,
-        dexNo: '0917',
-      },
-    },
+    'data': {
+      'id': 'ff315a13-b4dc-4601-aca3-13a16fda7a22',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tarountula',
+        'generation': 9,
+        'dexNo': '0917'
+      }
+    }
   },
   '4fd637d3-bee9-4d88-b064-48b692223905': {
-    data: {
-      id: '4fd637d3-bee9-4d88-b064-48b692223905',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Spidops',
-        generation: 9,
-        dexNo: '0918',
-      },
-    },
+    'data': {
+      'id': '4fd637d3-bee9-4d88-b064-48b692223905',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Spidops',
+        'generation': 9,
+        'dexNo': '0918'
+      }
+    }
   },
   '0e54499b-23d2-47c2-8d7d-0b764151486e': {
-    data: {
-      id: '0e54499b-23d2-47c2-8d7d-0b764151486e',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Nymble',
-        generation: 9,
-        dexNo: '0919',
-      },
-    },
+    'data': {
+      'id': '0e54499b-23d2-47c2-8d7d-0b764151486e',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Nymble',
+        'generation': 9,
+        'dexNo': '0919'
+      }
+    }
   },
   '3f84d6f5-3171-4e0a-b334-30a188fb1406': {
-    data: {
-      id: '3f84d6f5-3171-4e0a-b334-30a188fb1406',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Lokix',
-        generation: 9,
-        dexNo: '0920',
-      },
-    },
+    'data': {
+      'id': '3f84d6f5-3171-4e0a-b334-30a188fb1406',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Lokix',
+        'generation': 9,
+        'dexNo': '0920'
+      }
+    }
   },
   '73f482cc-0ea4-4c43-bd42-43ad868cf90a': {
-    data: {
-      id: '73f482cc-0ea4-4c43-bd42-43ad868cf90a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Pawmi',
-        generation: 9,
-        dexNo: '0921',
-      },
-    },
+    'data': {
+      'id': '73f482cc-0ea4-4c43-bd42-43ad868cf90a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Pawmi',
+        'generation': 9,
+        'dexNo': '0921'
+      }
+    }
   },
   '17441171-60a5-4dc8-b993-15c9101f8143': {
-    data: {
-      id: '17441171-60a5-4dc8-b993-15c9101f8143',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Pawmo',
-        generation: 9,
-        dexNo: '0922',
-      },
-    },
+    'data': {
+      'id': '17441171-60a5-4dc8-b993-15c9101f8143',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Pawmo',
+        'generation': 9,
+        'dexNo': '0922'
+      }
+    }
   },
   'c5ee9920-eaae-4713-93f4-2586a68b4f84': {
-    data: {
-      id: 'c5ee9920-eaae-4713-93f4-2586a68b4f84',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Pawmot',
-        generation: 9,
-        dexNo: '0923',
-      },
-    },
+    'data': {
+      'id': 'c5ee9920-eaae-4713-93f4-2586a68b4f84',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Pawmot',
+        'generation': 9,
+        'dexNo': '0923'
+      }
+    }
   },
   'f4124e83-411f-4391-84b8-8816a6716f69': {
-    data: {
-      id: 'f4124e83-411f-4391-84b8-8816a6716f69',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tandemaus',
-        generation: 9,
-        dexNo: '0924',
-      },
-    },
+    'data': {
+      'id': 'f4124e83-411f-4391-84b8-8816a6716f69',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tandemaus',
+        'generation': 9,
+        'dexNo': '0924'
+      }
+    }
   },
   'c3512215-48bc-4b64-97e6-2849cce0b1eb': {
-    data: {
-      id: 'c3512215-48bc-4b64-97e6-2849cce0b1eb',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Maushold',
-        generation: 9,
-        dexNo: '0925',
-      },
-    },
+    'data': {
+      'id': 'c3512215-48bc-4b64-97e6-2849cce0b1eb',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Maushold',
+        'generation': 9,
+        'dexNo': '0925'
+      }
+    }
   },
   'd55926ec-f0f9-478b-858a-83fe3a68be4d': {
-    data: {
-      id: 'd55926ec-f0f9-478b-858a-83fe3a68be4d',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Fidough',
-        generation: 9,
-        dexNo: '0926',
-      },
-    },
+    'data': {
+      'id': 'd55926ec-f0f9-478b-858a-83fe3a68be4d',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Fidough',
+        'generation': 9,
+        'dexNo': '0926'
+      }
+    }
   },
   '37ee9aab-6af8-41a7-99bc-768219c57c60': {
-    data: {
-      id: '37ee9aab-6af8-41a7-99bc-768219c57c60',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Dachsbun',
-        generation: 9,
-        dexNo: '0927',
-      },
-    },
+    'data': {
+      'id': '37ee9aab-6af8-41a7-99bc-768219c57c60',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Dachsbun',
+        'generation': 9,
+        'dexNo': '0927'
+      }
+    }
   },
   '31b03b29-3173-4950-91e9-0e8aeb568952': {
-    data: {
-      id: '31b03b29-3173-4950-91e9-0e8aeb568952',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Smoliv',
-        generation: 9,
-        dexNo: '0928',
-      },
-    },
+    'data': {
+      'id': '31b03b29-3173-4950-91e9-0e8aeb568952',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Smoliv',
+        'generation': 9,
+        'dexNo': '0928'
+      }
+    }
   },
   'fd63ca80-05ec-4d6c-9a7e-98153740b485': {
-    data: {
-      id: 'fd63ca80-05ec-4d6c-9a7e-98153740b485',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Dolliv',
-        generation: 9,
-        dexNo: '0929',
-      },
-    },
+    'data': {
+      'id': 'fd63ca80-05ec-4d6c-9a7e-98153740b485',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Dolliv',
+        'generation': 9,
+        'dexNo': '0929'
+      }
+    }
   },
   '7f3bc560-4acd-43b4-8413-d02ddd7dd6d8': {
-    data: {
-      id: '7f3bc560-4acd-43b4-8413-d02ddd7dd6d8',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Arboliva',
-        generation: 9,
-        dexNo: '0930',
-      },
-    },
+    'data': {
+      'id': '7f3bc560-4acd-43b4-8413-d02ddd7dd6d8',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Arboliva',
+        'generation': 9,
+        'dexNo': '0930'
+      }
+    }
   },
   '02307d61-3bd9-426c-8906-1d05ea1eac86': {
-    data: {
-      id: '02307d61-3bd9-426c-8906-1d05ea1eac86',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Squawkabilly',
-        generation: 9,
-        dexNo: '0931',
-      },
-    },
+    'data': {
+      'id': '02307d61-3bd9-426c-8906-1d05ea1eac86',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Squawkabilly',
+        'generation': 9,
+        'dexNo': '0931'
+      }
+    }
   },
   '5a857c69-3a7f-425a-82eb-a0a9fc0187f3': {
-    data: {
-      id: '5a857c69-3a7f-425a-82eb-a0a9fc0187f3',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Nacli',
-        generation: 9,
-        dexNo: '0932',
-      },
-    },
+    'data': {
+      'id': '5a857c69-3a7f-425a-82eb-a0a9fc0187f3',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Nacli',
+        'generation': 9,
+        'dexNo': '0932'
+      }
+    }
   },
   'ae6caff7-62a2-4d8c-92f2-49dd456e3089': {
-    data: {
-      id: 'ae6caff7-62a2-4d8c-92f2-49dd456e3089',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Naclstack',
-        generation: 9,
-        dexNo: '0933',
-      },
-    },
+    'data': {
+      'id': 'ae6caff7-62a2-4d8c-92f2-49dd456e3089',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Naclstack',
+        'generation': 9,
+        'dexNo': '0933'
+      }
+    }
   },
   '7e441215-4c6e-431f-81dd-f7ed8c35ccba': {
-    data: {
-      id: '7e441215-4c6e-431f-81dd-f7ed8c35ccba',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Garganacl',
-        generation: 9,
-        dexNo: '0934',
-      },
-    },
+    'data': {
+      'id': '7e441215-4c6e-431f-81dd-f7ed8c35ccba',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Garganacl',
+        'generation': 9,
+        'dexNo': '0934'
+      }
+    }
   },
   'cf3736c5-0795-49e3-b1e0-bb464936465d': {
-    data: {
-      id: 'cf3736c5-0795-49e3-b1e0-bb464936465d',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Charcadet',
-        generation: 9,
-        dexNo: '0935',
-      },
-    },
+    'data': {
+      'id': 'cf3736c5-0795-49e3-b1e0-bb464936465d',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Charcadet',
+        'generation': 9,
+        'dexNo': '0935'
+      }
+    }
   },
   'd54d9dc3-e2be-4e94-92fe-ef99ccfcc073': {
-    data: {
-      id: 'd54d9dc3-e2be-4e94-92fe-ef99ccfcc073',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Armarouge',
-        generation: 9,
-        dexNo: '0936',
-      },
-    },
+    'data': {
+      'id': 'd54d9dc3-e2be-4e94-92fe-ef99ccfcc073',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Armarouge',
+        'generation': 9,
+        'dexNo': '0936'
+      }
+    }
   },
   'adf10d91-040a-4dad-87c1-d8e66259ad30': {
-    data: {
-      id: 'adf10d91-040a-4dad-87c1-d8e66259ad30',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Ceruledge',
-        generation: 9,
-        dexNo: '0937',
-      },
-    },
+    'data': {
+      'id': 'adf10d91-040a-4dad-87c1-d8e66259ad30',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Ceruledge',
+        'generation': 9,
+        'dexNo': '0937'
+      }
+    }
   },
   'f524419c-0643-4277-a890-a0901271dd4b': {
-    data: {
-      id: 'f524419c-0643-4277-a890-a0901271dd4b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tadbulb',
-        generation: 9,
-        dexNo: '0938',
-      },
-    },
+    'data': {
+      'id': 'f524419c-0643-4277-a890-a0901271dd4b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tadbulb',
+        'generation': 9,
+        'dexNo': '0938'
+      }
+    }
   },
   '7d2e460b-6d0d-4bab-88c8-b45ef086049b': {
-    data: {
-      id: '7d2e460b-6d0d-4bab-88c8-b45ef086049b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Bellibolt',
-        generation: 9,
-        dexNo: '0939',
-      },
-    },
+    'data': {
+      'id': '7d2e460b-6d0d-4bab-88c8-b45ef086049b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Bellibolt',
+        'generation': 9,
+        'dexNo': '0939'
+      }
+    }
   },
   '2d1b2ae4-dcba-4ea6-af42-9d7022ff245b': {
-    data: {
-      id: '2d1b2ae4-dcba-4ea6-af42-9d7022ff245b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Wattrel',
-        generation: 9,
-        dexNo: '0940',
-      },
-    },
+    'data': {
+      'id': '2d1b2ae4-dcba-4ea6-af42-9d7022ff245b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Wattrel',
+        'generation': 9,
+        'dexNo': '0940'
+      }
+    }
   },
   '9d3f6d4c-c7d0-42e3-8d4c-52335c153444': {
-    data: {
-      id: '9d3f6d4c-c7d0-42e3-8d4c-52335c153444',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Kilowattrel',
-        generation: 9,
-        dexNo: '0941',
-      },
-    },
+    'data': {
+      'id': '9d3f6d4c-c7d0-42e3-8d4c-52335c153444',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Kilowattrel',
+        'generation': 9,
+        'dexNo': '0941'
+      }
+    }
   },
   '6bd0e7ce-85ac-459a-b37d-426a0ffe2dc4': {
-    data: {
-      id: '6bd0e7ce-85ac-459a-b37d-426a0ffe2dc4',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Maschiff',
-        generation: 9,
-        dexNo: '0942',
-      },
-    },
+    'data': {
+      'id': '6bd0e7ce-85ac-459a-b37d-426a0ffe2dc4',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Maschiff',
+        'generation': 9,
+        'dexNo': '0942'
+      }
+    }
   },
   'd186901b-7433-45ec-abf6-2b4e6cd748c1': {
-    data: {
-      id: 'd186901b-7433-45ec-abf6-2b4e6cd748c1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Mabosstiff',
-        generation: 9,
-        dexNo: '0943',
-      },
-    },
+    'data': {
+      'id': 'd186901b-7433-45ec-abf6-2b4e6cd748c1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Mabosstiff',
+        'generation': 9,
+        'dexNo': '0943'
+      }
+    }
   },
   '45f04ea0-98db-471f-bdb9-c96ccbd16bb1': {
-    data: {
-      id: '45f04ea0-98db-471f-bdb9-c96ccbd16bb1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Shroodle',
-        generation: 9,
-        dexNo: '0944',
-      },
-    },
+    'data': {
+      'id': '45f04ea0-98db-471f-bdb9-c96ccbd16bb1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Shroodle',
+        'generation': 9,
+        'dexNo': '0944'
+      }
+    }
   },
   'b26bad43-0180-44d5-809a-fac35f92c24f': {
-    data: {
-      id: 'b26bad43-0180-44d5-809a-fac35f92c24f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Grafaiai',
-        generation: 9,
-        dexNo: '0945',
-      },
-    },
+    'data': {
+      'id': 'b26bad43-0180-44d5-809a-fac35f92c24f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Grafaiai',
+        'generation': 9,
+        'dexNo': '0945'
+      }
+    }
   },
   '5cd9759a-4605-4bca-a47e-6c2dcb320ed6': {
-    data: {
-      id: '5cd9759a-4605-4bca-a47e-6c2dcb320ed6',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Bramblin',
-        generation: 9,
-        dexNo: '0946',
-      },
-    },
+    'data': {
+      'id': '5cd9759a-4605-4bca-a47e-6c2dcb320ed6',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Bramblin',
+        'generation': 9,
+        'dexNo': '0946'
+      }
+    }
   },
   'cc27a9a5-dce2-4e9e-9106-32bb968abdf0': {
-    data: {
-      id: 'cc27a9a5-dce2-4e9e-9106-32bb968abdf0',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Brambleghast',
-        generation: 9,
-        dexNo: '0947',
-      },
-    },
+    'data': {
+      'id': 'cc27a9a5-dce2-4e9e-9106-32bb968abdf0',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Brambleghast',
+        'generation': 9,
+        'dexNo': '0947'
+      }
+    }
   },
   '6b57b43b-60e3-44e8-b740-0635e8e899ab': {
-    data: {
-      id: '6b57b43b-60e3-44e8-b740-0635e8e899ab',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Toedscool',
-        generation: 9,
-        dexNo: '0948',
-      },
-    },
+    'data': {
+      'id': '6b57b43b-60e3-44e8-b740-0635e8e899ab',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Toedscool',
+        'generation': 9,
+        'dexNo': '0948'
+      }
+    }
   },
   'af471216-7337-4bb7-9a9a-8813d20503e2': {
-    data: {
-      id: 'af471216-7337-4bb7-9a9a-8813d20503e2',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Toedscruel',
-        generation: 9,
-        dexNo: '0949',
-      },
-    },
+    'data': {
+      'id': 'af471216-7337-4bb7-9a9a-8813d20503e2',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Toedscruel',
+        'generation': 9,
+        'dexNo': '0949'
+      }
+    }
   },
   '454e6e19-6c37-44d9-9bb5-c6051c76ffbc': {
-    data: {
-      id: '454e6e19-6c37-44d9-9bb5-c6051c76ffbc',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Klawf',
-        generation: 9,
-        dexNo: '0950',
-      },
-    },
+    'data': {
+      'id': '454e6e19-6c37-44d9-9bb5-c6051c76ffbc',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Klawf',
+        'generation': 9,
+        'dexNo': '0950'
+      }
+    }
   },
   'a387d04d-c518-4e1f-821d-aca25f301019': {
-    data: {
-      id: 'a387d04d-c518-4e1f-821d-aca25f301019',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Capsakid',
-        generation: 9,
-        dexNo: '0951',
-      },
-    },
+    'data': {
+      'id': 'a387d04d-c518-4e1f-821d-aca25f301019',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Capsakid',
+        'generation': 9,
+        'dexNo': '0951'
+      }
+    }
   },
   '2e5a63fd-d522-467e-8991-b99f548aba04': {
-    data: {
-      id: '2e5a63fd-d522-467e-8991-b99f548aba04',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Scovillain',
-        generation: 9,
-        dexNo: '0952',
-      },
-    },
+    'data': {
+      'id': '2e5a63fd-d522-467e-8991-b99f548aba04',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Scovillain',
+        'generation': 9,
+        'dexNo': '0952'
+      }
+    }
   },
   '2107fb19-996e-40ad-bae7-55c098ad3857': {
-    data: {
-      id: '2107fb19-996e-40ad-bae7-55c098ad3857',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Rellor',
-        generation: 9,
-        dexNo: '0953',
-      },
-    },
+    'data': {
+      'id': '2107fb19-996e-40ad-bae7-55c098ad3857',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Rellor',
+        'generation': 9,
+        'dexNo': '0953'
+      }
+    }
   },
   'efaff519-b533-4104-b228-2b0b8570f639': {
-    data: {
-      id: 'efaff519-b533-4104-b228-2b0b8570f639',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Rabsca',
-        generation: 9,
-        dexNo: '0954',
-      },
-    },
+    'data': {
+      'id': 'efaff519-b533-4104-b228-2b0b8570f639',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Rabsca',
+        'generation': 9,
+        'dexNo': '0954'
+      }
+    }
   },
   'fb4d3a7e-46b9-4698-ad01-ff1f71563ea6': {
-    data: {
-      id: 'fb4d3a7e-46b9-4698-ad01-ff1f71563ea6',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Flittle',
-        generation: 9,
-        dexNo: '0955',
-      },
-    },
+    'data': {
+      'id': 'fb4d3a7e-46b9-4698-ad01-ff1f71563ea6',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Flittle',
+        'generation': 9,
+        'dexNo': '0955'
+      }
+    }
   },
   'f5366717-4066-46ee-b760-5e897c4bdc59': {
-    data: {
-      id: 'f5366717-4066-46ee-b760-5e897c4bdc59',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Espathra',
-        generation: 9,
-        dexNo: '0956',
-      },
-    },
+    'data': {
+      'id': 'f5366717-4066-46ee-b760-5e897c4bdc59',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Espathra',
+        'generation': 9,
+        'dexNo': '0956'
+      }
+    }
   },
   '9e8605f4-17fc-4649-ad7a-d9e9a009336f': {
-    data: {
-      id: '9e8605f4-17fc-4649-ad7a-d9e9a009336f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tinkatink',
-        generation: 9,
-        dexNo: '0957',
-      },
-    },
+    'data': {
+      'id': '9e8605f4-17fc-4649-ad7a-d9e9a009336f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tinkatink',
+        'generation': 9,
+        'dexNo': '0957'
+      }
+    }
   },
   '8b3edd23-8250-4258-bb59-4f8b3c940585': {
-    data: {
-      id: '8b3edd23-8250-4258-bb59-4f8b3c940585',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tinkatuff',
-        generation: 9,
-        dexNo: '0958',
-      },
-    },
+    'data': {
+      'id': '8b3edd23-8250-4258-bb59-4f8b3c940585',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tinkatuff',
+        'generation': 9,
+        'dexNo': '0958'
+      }
+    }
   },
   '95876c88-3045-42a2-9151-c3724a3053b4': {
-    data: {
-      id: '95876c88-3045-42a2-9151-c3724a3053b4',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tinkaton',
-        generation: 9,
-        dexNo: '0959',
-      },
-    },
+    'data': {
+      'id': '95876c88-3045-42a2-9151-c3724a3053b4',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tinkaton',
+        'generation': 9,
+        'dexNo': '0959'
+      }
+    }
   },
   'b64a786c-16b2-49b4-a507-5debb67a8ae5': {
-    data: {
-      id: 'b64a786c-16b2-49b4-a507-5debb67a8ae5',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Wiglett',
-        generation: 9,
-        dexNo: '0960',
-      },
-    },
+    'data': {
+      'id': 'b64a786c-16b2-49b4-a507-5debb67a8ae5',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Wiglett',
+        'generation': 9,
+        'dexNo': '0960'
+      }
+    }
   },
   'e6f7da52-7388-4412-80c9-29c2fe1d1a9a': {
-    data: {
-      id: 'e6f7da52-7388-4412-80c9-29c2fe1d1a9a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Wugtrio',
-        generation: 9,
-        dexNo: '0961',
-      },
-    },
+    'data': {
+      'id': 'e6f7da52-7388-4412-80c9-29c2fe1d1a9a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Wugtrio',
+        'generation': 9,
+        'dexNo': '0961'
+      }
+    }
   },
   '4c05a200-9780-4e80-93dd-607d4b6a36dc': {
-    data: {
-      id: '4c05a200-9780-4e80-93dd-607d4b6a36dc',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Bombirdier',
-        generation: 9,
-        dexNo: '0962',
-      },
-    },
+    'data': {
+      'id': '4c05a200-9780-4e80-93dd-607d4b6a36dc',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Bombirdier',
+        'generation': 9,
+        'dexNo': '0962'
+      }
+    }
   },
   'a1209dfd-af3a-46d2-a74e-c8feccf52785': {
-    data: {
-      id: 'a1209dfd-af3a-46d2-a74e-c8feccf52785',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Finizen',
-        generation: 9,
-        dexNo: '0963',
-      },
-    },
+    'data': {
+      'id': 'a1209dfd-af3a-46d2-a74e-c8feccf52785',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Finizen',
+        'generation': 9,
+        'dexNo': '0963'
+      }
+    }
   },
   '124eda80-d85c-4f4f-8f45-5017dac08b79': {
-    data: {
-      id: '124eda80-d85c-4f4f-8f45-5017dac08b79',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Palafin',
-        generation: 9,
-        dexNo: '0964',
-      },
-    },
+    'data': {
+      'id': '124eda80-d85c-4f4f-8f45-5017dac08b79',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Palafin',
+        'generation': 9,
+        'dexNo': '0964'
+      }
+    }
   },
   '95a16623-843f-4696-abd8-3c72f24e24d1': {
-    data: {
-      id: '95a16623-843f-4696-abd8-3c72f24e24d1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Varoom',
-        generation: 9,
-        dexNo: '0965',
-      },
-    },
+    'data': {
+      'id': '95a16623-843f-4696-abd8-3c72f24e24d1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Varoom',
+        'generation': 9,
+        'dexNo': '0965'
+      }
+    }
   },
   '9139f8c0-60db-4cf1-9b6c-4125e2568142': {
-    data: {
-      id: '9139f8c0-60db-4cf1-9b6c-4125e2568142',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Revavroom',
-        generation: 9,
-        dexNo: '0966',
-      },
-    },
+    'data': {
+      'id': '9139f8c0-60db-4cf1-9b6c-4125e2568142',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Revavroom',
+        'generation': 9,
+        'dexNo': '0966'
+      }
+    }
   },
   'c14ee623-1853-4da3-9021-f55805c1bc71': {
-    data: {
-      id: 'c14ee623-1853-4da3-9021-f55805c1bc71',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Cyclizar',
-        generation: 9,
-        dexNo: '0967',
-      },
-    },
+    'data': {
+      'id': 'c14ee623-1853-4da3-9021-f55805c1bc71',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Cyclizar',
+        'generation': 9,
+        'dexNo': '0967'
+      }
+    }
   },
   '4fff0c25-e12a-4d29-8880-a76dc2b1cc77': {
-    data: {
-      id: '4fff0c25-e12a-4d29-8880-a76dc2b1cc77',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Orthworm',
-        generation: 9,
-        dexNo: '0968',
-      },
-    },
+    'data': {
+      'id': '4fff0c25-e12a-4d29-8880-a76dc2b1cc77',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Orthworm',
+        'generation': 9,
+        'dexNo': '0968'
+      }
+    }
   },
   '448daffc-668f-4476-b6e4-19111c496573': {
-    data: {
-      id: '448daffc-668f-4476-b6e4-19111c496573',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Glimmet',
-        generation: 9,
-        dexNo: '0969',
-      },
-    },
+    'data': {
+      'id': '448daffc-668f-4476-b6e4-19111c496573',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Glimmet',
+        'generation': 9,
+        'dexNo': '0969'
+      }
+    }
   },
   '94e3ad92-d4e9-4e65-9165-b5b6d7eabfcd': {
-    data: {
-      id: '94e3ad92-d4e9-4e65-9165-b5b6d7eabfcd',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Glimmora',
-        generation: 9,
-        dexNo: '0970',
-      },
-    },
+    'data': {
+      'id': '94e3ad92-d4e9-4e65-9165-b5b6d7eabfcd',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Glimmora',
+        'generation': 9,
+        'dexNo': '0970'
+      }
+    }
   },
   'cc565cf4-fd40-4f76-accb-bcf8cd051fdc': {
-    data: {
-      id: 'cc565cf4-fd40-4f76-accb-bcf8cd051fdc',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Greavard',
-        generation: 9,
-        dexNo: '0971',
-      },
-    },
+    'data': {
+      'id': 'cc565cf4-fd40-4f76-accb-bcf8cd051fdc',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Greavard',
+        'generation': 9,
+        'dexNo': '0971'
+      }
+    }
   },
   '88183b39-8f47-4cb5-aef0-a60aff9aad59': {
-    data: {
-      id: '88183b39-8f47-4cb5-aef0-a60aff9aad59',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Houndstone',
-        generation: 9,
-        dexNo: '0972',
-      },
-    },
+    'data': {
+      'id': '88183b39-8f47-4cb5-aef0-a60aff9aad59',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Houndstone',
+        'generation': 9,
+        'dexNo': '0972'
+      }
+    }
   },
   'c2443651-d521-4dcd-8539-a00b84a4efaf': {
-    data: {
-      id: 'c2443651-d521-4dcd-8539-a00b84a4efaf',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Flamigo',
-        generation: 9,
-        dexNo: '0973',
-      },
-    },
+    'data': {
+      'id': 'c2443651-d521-4dcd-8539-a00b84a4efaf',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Flamigo',
+        'generation': 9,
+        'dexNo': '0973'
+      }
+    }
   },
   'ffdb809b-c0f9-4f09-8e72-2f3ca45fa74f': {
-    data: {
-      id: 'ffdb809b-c0f9-4f09-8e72-2f3ca45fa74f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Cetoddle',
-        generation: 9,
-        dexNo: '0974',
-      },
-    },
+    'data': {
+      'id': 'ffdb809b-c0f9-4f09-8e72-2f3ca45fa74f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Cetoddle',
+        'generation': 9,
+        'dexNo': '0974'
+      }
+    }
   },
   'e8f00ab7-bdbc-43a6-9acb-064315e7f97e': {
-    data: {
-      id: 'e8f00ab7-bdbc-43a6-9acb-064315e7f97e',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Cetitan',
-        generation: 9,
-        dexNo: '0975',
-      },
-    },
+    'data': {
+      'id': 'e8f00ab7-bdbc-43a6-9acb-064315e7f97e',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Cetitan',
+        'generation': 9,
+        'dexNo': '0975'
+      }
+    }
   },
   '8d19f40c-88a8-49ad-9616-1265bc962650': {
-    data: {
-      id: '8d19f40c-88a8-49ad-9616-1265bc962650',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Veluza',
-        generation: 9,
-        dexNo: '0976',
-      },
-    },
+    'data': {
+      'id': '8d19f40c-88a8-49ad-9616-1265bc962650',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Veluza',
+        'generation': 9,
+        'dexNo': '0976'
+      }
+    }
   },
   'eede505c-d4c0-41a8-93c2-34ec4913ad3b': {
-    data: {
-      id: 'eede505c-d4c0-41a8-93c2-34ec4913ad3b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Dondozo',
-        generation: 9,
-        dexNo: '0977',
-      },
-    },
+    'data': {
+      'id': 'eede505c-d4c0-41a8-93c2-34ec4913ad3b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Dondozo',
+        'generation': 9,
+        'dexNo': '0977'
+      }
+    }
   },
   '5b93d3de-49ff-40ce-bbdf-750b58d0203c': {
-    data: {
-      id: '5b93d3de-49ff-40ce-bbdf-750b58d0203c',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Tatsugiri',
-        generation: 9,
-        dexNo: '0978',
-      },
-    },
+    'data': {
+      'id': '5b93d3de-49ff-40ce-bbdf-750b58d0203c',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Tatsugiri',
+        'generation': 9,
+        'dexNo': '0978'
+      }
+    }
   },
   '8833b9a4-399e-4a43-a864-3e1b0393fd01': {
-    data: {
-      id: '8833b9a4-399e-4a43-a864-3e1b0393fd01',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Annihilape',
-        generation: 9,
-        dexNo: '0979',
-      },
-    },
+    'data': {
+      'id': '8833b9a4-399e-4a43-a864-3e1b0393fd01',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Annihilape',
+        'generation': 9,
+        'dexNo': '0979'
+      }
+    }
   },
   '7ac76722-52a9-4555-8735-14507ff65a73': {
-    data: {
-      id: '7ac76722-52a9-4555-8735-14507ff65a73',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Clodsire',
-        generation: 9,
-        dexNo: '0980',
-      },
-    },
+    'data': {
+      'id': '7ac76722-52a9-4555-8735-14507ff65a73',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Clodsire',
+        'generation': 9,
+        'dexNo': '0980'
+      }
+    }
   },
   '39fd1682-083c-46f3-934c-9230888b388a': {
-    data: {
-      id: '39fd1682-083c-46f3-934c-9230888b388a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Farigiraf',
-        generation: 9,
-        dexNo: '0981',
-      },
-    },
+    'data': {
+      'id': '39fd1682-083c-46f3-934c-9230888b388a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Farigiraf',
+        'generation': 9,
+        'dexNo': '0981'
+      }
+    }
   },
   'f838a0f2-c614-40b7-b3ad-c09e5b0e77be': {
-    data: {
-      id: 'f838a0f2-c614-40b7-b3ad-c09e5b0e77be',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Dudunsparce',
-        generation: 9,
-        dexNo: '0982',
-      },
-    },
+    'data': {
+      'id': 'f838a0f2-c614-40b7-b3ad-c09e5b0e77be',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Dudunsparce',
+        'generation': 9,
+        'dexNo': '0982'
+      }
+    }
   },
   'b57bc54a-4f8f-4c36-82d5-57493b6fe376': {
-    data: {
-      id: 'b57bc54a-4f8f-4c36-82d5-57493b6fe376',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Kingambit',
-        generation: 9,
-        dexNo: '0983',
-      },
-    },
+    'data': {
+      'id': 'b57bc54a-4f8f-4c36-82d5-57493b6fe376',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Kingambit',
+        'generation': 9,
+        'dexNo': '0983'
+      }
+    }
   },
   '1f773ab0-6d6f-4853-a4a4-e174c167286f': {
-    data: {
-      id: '1f773ab0-6d6f-4853-a4a4-e174c167286f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Great Tusk',
-        generation: 9,
-        dexNo: '0984',
-      },
-    },
+    'data': {
+      'id': '1f773ab0-6d6f-4853-a4a4-e174c167286f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Great Tusk',
+        'generation': 9,
+        'dexNo': '0984'
+      }
+    }
   },
   '191d3a48-0697-4a8c-9f20-25d0de2e1e05': {
-    data: {
-      id: '191d3a48-0697-4a8c-9f20-25d0de2e1e05',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Scream Tail',
-        generation: 9,
-        dexNo: '0985',
-      },
-    },
+    'data': {
+      'id': '191d3a48-0697-4a8c-9f20-25d0de2e1e05',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Scream Tail',
+        'generation': 9,
+        'dexNo': '0985'
+      }
+    }
   },
   '049b64b0-42a8-47b0-983b-a0bddbac6e03': {
-    data: {
-      id: '049b64b0-42a8-47b0-983b-a0bddbac6e03',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Brute Bonnet',
-        generation: 9,
-        dexNo: '0986',
-      },
-    },
+    'data': {
+      'id': '049b64b0-42a8-47b0-983b-a0bddbac6e03',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Brute Bonnet',
+        'generation': 9,
+        'dexNo': '0986'
+      }
+    }
   },
   'a711e10f-5109-43b8-8991-b826dcf1ce58': {
-    data: {
-      id: 'a711e10f-5109-43b8-8991-b826dcf1ce58',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Flutter Mane',
-        generation: 9,
-        dexNo: '0987',
-      },
-    },
+    'data': {
+      'id': 'a711e10f-5109-43b8-8991-b826dcf1ce58',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Flutter Mane',
+        'generation': 9,
+        'dexNo': '0987'
+      }
+    }
   },
   '96348370-cf6d-4674-8c33-d310f34a8708': {
-    data: {
-      id: '96348370-cf6d-4674-8c33-d310f34a8708',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Slither Wing',
-        generation: 9,
-        dexNo: '0988',
-      },
-    },
+    'data': {
+      'id': '96348370-cf6d-4674-8c33-d310f34a8708',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Slither Wing',
+        'generation': 9,
+        'dexNo': '0988'
+      }
+    }
   },
   '97fcd9cb-845a-4c0a-9e42-192be7012d96': {
-    data: {
-      id: '97fcd9cb-845a-4c0a-9e42-192be7012d96',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Sandy Shocks',
-        generation: 9,
-        dexNo: '0989',
-      },
-    },
+    'data': {
+      'id': '97fcd9cb-845a-4c0a-9e42-192be7012d96',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Sandy Shocks',
+        'generation': 9,
+        'dexNo': '0989'
+      }
+    }
   },
   '47c4097f-f029-4b07-913e-d1eb482a4824': {
-    data: {
-      id: '47c4097f-f029-4b07-913e-d1eb482a4824',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Treads',
-        generation: 9,
-        dexNo: '0990',
-      },
-    },
+    'data': {
+      'id': '47c4097f-f029-4b07-913e-d1eb482a4824',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Treads',
+        'generation': 9,
+        'dexNo': '0990'
+      }
+    }
   },
   'd067ea89-4cef-4a4e-9331-2d031120a807': {
-    data: {
-      id: 'd067ea89-4cef-4a4e-9331-2d031120a807',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Bundle',
-        generation: 9,
-        dexNo: '0991',
-      },
-    },
+    'data': {
+      'id': 'd067ea89-4cef-4a4e-9331-2d031120a807',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Bundle',
+        'generation': 9,
+        'dexNo': '0991'
+      }
+    }
   },
   'b9e7c43e-2141-4669-8b3c-a1f367d94c91': {
-    data: {
-      id: 'b9e7c43e-2141-4669-8b3c-a1f367d94c91',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Hands',
-        generation: 9,
-        dexNo: '0992',
-      },
-    },
+    'data': {
+      'id': 'b9e7c43e-2141-4669-8b3c-a1f367d94c91',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Hands',
+        'generation': 9,
+        'dexNo': '0992'
+      }
+    }
   },
   '4aeca7cb-0977-46ae-8269-282e1783eae1': {
-    data: {
-      id: '4aeca7cb-0977-46ae-8269-282e1783eae1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Jugulis',
-        generation: 9,
-        dexNo: '0993',
-      },
-    },
+    'data': {
+      'id': '4aeca7cb-0977-46ae-8269-282e1783eae1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Jugulis',
+        'generation': 9,
+        'dexNo': '0993'
+      }
+    }
   },
   'ec0fda70-66b3-483f-9142-b72d07545d8a': {
-    data: {
-      id: 'ec0fda70-66b3-483f-9142-b72d07545d8a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Moth',
-        generation: 9,
-        dexNo: '0994',
-      },
-    },
+    'data': {
+      'id': 'ec0fda70-66b3-483f-9142-b72d07545d8a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Moth',
+        'generation': 9,
+        'dexNo': '0994'
+      }
+    }
   },
   'e49ae428-49a7-4980-846d-ba20013867dc': {
-    data: {
-      id: 'e49ae428-49a7-4980-846d-ba20013867dc',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Thorns',
-        generation: 9,
-        dexNo: '0995',
-      },
-    },
+    'data': {
+      'id': 'e49ae428-49a7-4980-846d-ba20013867dc',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Thorns',
+        'generation': 9,
+        'dexNo': '0995'
+      }
+    }
   },
   '9f8c7a79-1fcc-4c5c-95b5-a6e49d170c5b': {
-    data: {
-      id: '9f8c7a79-1fcc-4c5c-95b5-a6e49d170c5b',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Frigibax',
-        generation: 9,
-        dexNo: '0996',
-      },
-    },
+    'data': {
+      'id': '9f8c7a79-1fcc-4c5c-95b5-a6e49d170c5b',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Frigibax',
+        'generation': 9,
+        'dexNo': '0996'
+      }
+    }
   },
   '3e686abb-7820-4b27-970b-f1101c3349c3': {
-    data: {
-      id: '3e686abb-7820-4b27-970b-f1101c3349c3',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Arctibax',
-        generation: 9,
-        dexNo: '0997',
-      },
-    },
+    'data': {
+      'id': '3e686abb-7820-4b27-970b-f1101c3349c3',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Arctibax',
+        'generation': 9,
+        'dexNo': '0997'
+      }
+    }
   },
   'f612cbe0-8b28-4f51-9822-7969c039038d': {
-    data: {
-      id: 'f612cbe0-8b28-4f51-9822-7969c039038d',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Baxcalibur',
-        generation: 9,
-        dexNo: '0998',
-      },
-    },
+    'data': {
+      'id': 'f612cbe0-8b28-4f51-9822-7969c039038d',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Baxcalibur',
+        'generation': 9,
+        'dexNo': '0998'
+      }
+    }
   },
   'd36b8a6b-b5d7-48f5-bf8e-86906194c28d': {
-    data: {
-      id: 'd36b8a6b-b5d7-48f5-bf8e-86906194c28d',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Gimmighoul',
-        generation: 9,
-        dexNo: '0999',
-      },
-    },
+    'data': {
+      'id': 'd36b8a6b-b5d7-48f5-bf8e-86906194c28d',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Gimmighoul',
+        'generation': 9,
+        'dexNo': '0999'
+      }
+    }
   },
   'b589bb28-7bbf-4d9f-a8e6-6589783ae375': {
-    data: {
-      id: 'b589bb28-7bbf-4d9f-a8e6-6589783ae375',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Gholdengo',
-        generation: 9,
-        dexNo: '1000',
-      },
-    },
+    'data': {
+      'id': 'b589bb28-7bbf-4d9f-a8e6-6589783ae375',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Gholdengo',
+        'generation': 9,
+        'dexNo': '1000'
+      }
+    }
   },
   '531c3f97-1e8e-424d-9d64-534d598bbb7c': {
-    data: {
-      id: '531c3f97-1e8e-424d-9d64-534d598bbb7c',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Wo-Chien',
-        generation: 9,
-        dexNo: '1001',
-      },
-    },
+    'data': {
+      'id': '531c3f97-1e8e-424d-9d64-534d598bbb7c',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Wo-Chien',
+        'generation': 9,
+        'dexNo': '1001'
+      }
+    }
   },
   '4442b6c2-ce78-4e81-91a0-6b85900ed5d8': {
-    data: {
-      id: '4442b6c2-ce78-4e81-91a0-6b85900ed5d8',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Chien-Pao',
-        generation: 9,
-        dexNo: '1002',
-      },
-    },
+    'data': {
+      'id': '4442b6c2-ce78-4e81-91a0-6b85900ed5d8',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Chien-Pao',
+        'generation': 9,
+        'dexNo': '1002'
+      }
+    }
   },
   'eac6a005-b9bc-46ec-895d-127fcf22d3c6': {
-    data: {
-      id: 'eac6a005-b9bc-46ec-895d-127fcf22d3c6',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Ting-Lu',
-        generation: 9,
-        dexNo: '1003',
-      },
-    },
+    'data': {
+      'id': 'eac6a005-b9bc-46ec-895d-127fcf22d3c6',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Ting-Lu',
+        'generation': 9,
+        'dexNo': '1003'
+      }
+    }
   },
   '2a258f57-9268-42d0-8363-35ac72f4575f': {
-    data: {
-      id: '2a258f57-9268-42d0-8363-35ac72f4575f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Chi-Yu',
-        generation: 9,
-        dexNo: '1004',
-      },
-    },
+    'data': {
+      'id': '2a258f57-9268-42d0-8363-35ac72f4575f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Chi-Yu',
+        'generation': 9,
+        'dexNo': '1004'
+      }
+    }
   },
   'c291dd7a-074f-4a64-831d-e759beedb893': {
-    data: {
-      id: 'c291dd7a-074f-4a64-831d-e759beedb893',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Roaring Moon',
-        generation: 9,
-        dexNo: '1005',
-      },
-    },
+    'data': {
+      'id': 'c291dd7a-074f-4a64-831d-e759beedb893',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Roaring Moon',
+        'generation': 9,
+        'dexNo': '1005'
+      }
+    }
   },
   'cbd0b155-20c3-4d26-9350-5c590f17c39d': {
-    data: {
-      id: 'cbd0b155-20c3-4d26-9350-5c590f17c39d',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Valiant',
-        generation: 9,
-        dexNo: '1006',
-      },
-    },
+    'data': {
+      'id': 'cbd0b155-20c3-4d26-9350-5c590f17c39d',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Valiant',
+        'generation': 9,
+        'dexNo': '1006'
+      }
+    }
   },
   '5225adea-9aa5-4d0c-94fd-dcf00ea83999': {
-    data: {
-      id: '5225adea-9aa5-4d0c-94fd-dcf00ea83999',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Koraidon',
-        generation: 9,
-        dexNo: '1007',
-      },
-    },
+    'data': {
+      'id': '5225adea-9aa5-4d0c-94fd-dcf00ea83999',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Koraidon',
+        'generation': 9,
+        'dexNo': '1007'
+      }
+    }
   },
   '8c839b31-a8b3-4612-8cb3-bea16316cd6c': {
-    data: {
-      id: '8c839b31-a8b3-4612-8cb3-bea16316cd6c',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Miraidon',
-        generation: 9,
-        dexNo: '1008',
-      },
-    },
+    'data': {
+      'id': '8c839b31-a8b3-4612-8cb3-bea16316cd6c',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Miraidon',
+        'generation': 9,
+        'dexNo': '1008'
+      }
+    }
   },
   '19d3cce3-44e6-420f-be43-2c2d06b790ab': {
-    data: {
-      id: '19d3cce3-44e6-420f-be43-2c2d06b790ab',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Walking Wake',
-        generation: 9,
-        dexNo: '1009',
-      },
-    },
+    'data': {
+      'id': '19d3cce3-44e6-420f-be43-2c2d06b790ab',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Walking Wake',
+        'generation': 9,
+        'dexNo': '1009'
+      }
+    }
   },
   '90b67db6-f398-4b51-a950-0c4b096ac88f': {
-    data: {
-      id: '90b67db6-f398-4b51-a950-0c4b096ac88f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Leaves',
-        generation: 9,
-        dexNo: '1010',
-      },
-    },
+    'data': {
+      'id': '90b67db6-f398-4b51-a950-0c4b096ac88f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Leaves',
+        'generation': 9,
+        'dexNo': '1010'
+      }
+    }
   },
   'dfe7efd2-4df9-4ea7-bad4-e3efc621a36a': {
-    data: {
-      id: 'dfe7efd2-4df9-4ea7-bad4-e3efc621a36a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Dipplin',
-        generation: 9,
-        dexNo: '1011',
-      },
-    },
+    'data': {
+      'id': 'dfe7efd2-4df9-4ea7-bad4-e3efc621a36a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Dipplin',
+        'generation': 9,
+        'dexNo': '1011'
+      }
+    }
   },
   '1e1957a8-49bd-49e6-ab63-0ce298dabaca': {
-    data: {
-      id: '1e1957a8-49bd-49e6-ab63-0ce298dabaca',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Poltchageist',
-        generation: 9,
-        dexNo: '1012',
-      },
-    },
+    'data': {
+      'id': '1e1957a8-49bd-49e6-ab63-0ce298dabaca',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Poltchageist',
+        'generation': 9,
+        'dexNo': '1012'
+      }
+    }
   },
   'd0f63092-256c-4175-925f-3b98acc308e2': {
-    data: {
-      id: 'd0f63092-256c-4175-925f-3b98acc308e2',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Sinistcha',
-        generation: 9,
-        dexNo: '1013',
-      },
-    },
+    'data': {
+      'id': 'd0f63092-256c-4175-925f-3b98acc308e2',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Sinistcha',
+        'generation': 9,
+        'dexNo': '1013'
+      }
+    }
   },
   '64427af3-0c69-4499-baa3-4612595fa5a1': {
-    data: {
-      id: '64427af3-0c69-4499-baa3-4612595fa5a1',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Okidogi',
-        generation: 9,
-        dexNo: '1014',
-      },
-    },
+    'data': {
+      'id': '64427af3-0c69-4499-baa3-4612595fa5a1',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Okidogi',
+        'generation': 9,
+        'dexNo': '1014'
+      }
+    }
   },
   '16706316-ea5d-46d7-9200-af7da0f0d265': {
-    data: {
-      id: '16706316-ea5d-46d7-9200-af7da0f0d265',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Munkidori',
-        generation: 9,
-        dexNo: '1015',
-      },
-    },
+    'data': {
+      'id': '16706316-ea5d-46d7-9200-af7da0f0d265',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Munkidori',
+        'generation': 9,
+        'dexNo': '1015'
+      }
+    }
   },
   'd405890a-bf71-4e65-916d-d404c827e792': {
-    data: {
-      id: 'd405890a-bf71-4e65-916d-d404c827e792',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Fezandipiti',
-        generation: 9,
-        dexNo: '1016',
-      },
-    },
+    'data': {
+      'id': 'd405890a-bf71-4e65-916d-d404c827e792',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Fezandipiti',
+        'generation': 9,
+        'dexNo': '1016'
+      }
+    }
   },
   '6788b790-7a6b-4162-8677-6c27290f24de': {
-    data: {
-      id: '6788b790-7a6b-4162-8677-6c27290f24de',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Ogerpon',
-        generation: 9,
-        dexNo: '1017',
-      },
-    },
+    'data': {
+      'id': '6788b790-7a6b-4162-8677-6c27290f24de',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Ogerpon',
+        'generation': 9,
+        'dexNo': '1017'
+      }
+    }
   },
   '748e2503-99c6-4c50-83fb-a87517b07b9a': {
-    data: {
-      id: '748e2503-99c6-4c50-83fb-a87517b07b9a',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Archaludon',
-        generation: 9,
-        dexNo: '1018',
-      },
-    },
+    'data': {
+      'id': '748e2503-99c6-4c50-83fb-a87517b07b9a',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Archaludon',
+        'generation': 9,
+        'dexNo': '1018'
+      }
+    }
   },
   '6e0ef545-2fca-4a75-b56c-eea58a86cc13': {
-    data: {
-      id: '6e0ef545-2fca-4a75-b56c-eea58a86cc13',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Hydrapple',
-        generation: 9,
-        dexNo: '1019',
-      },
-    },
+    'data': {
+      'id': '6e0ef545-2fca-4a75-b56c-eea58a86cc13',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Hydrapple',
+        'generation': 9,
+        'dexNo': '1019'
+      }
+    }
   },
   '26aba993-9076-47e0-b47d-0c1a725fae77': {
-    data: {
-      id: '26aba993-9076-47e0-b47d-0c1a725fae77',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Gouging Fire',
-        generation: 9,
-        dexNo: '1020',
-      },
-    },
+    'data': {
+      'id': '26aba993-9076-47e0-b47d-0c1a725fae77',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Gouging Fire',
+        'generation': 9,
+        'dexNo': '1020'
+      }
+    }
   },
   '06aee43b-21ca-4a0a-ad5c-e20cb52035d7': {
-    data: {
-      id: '06aee43b-21ca-4a0a-ad5c-e20cb52035d7',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Raging Bolt',
-        generation: 9,
-        dexNo: '1021',
-      },
-    },
+    'data': {
+      'id': '06aee43b-21ca-4a0a-ad5c-e20cb52035d7',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Raging Bolt',
+        'generation': 9,
+        'dexNo': '1021'
+      }
+    }
   },
   '9aa67ef5-1d68-48c7-9a3c-64ea0a3981df': {
-    data: {
-      id: '9aa67ef5-1d68-48c7-9a3c-64ea0a3981df',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Boulder',
-        generation: 9,
-        dexNo: '1022',
-      },
-    },
+    'data': {
+      'id': '9aa67ef5-1d68-48c7-9a3c-64ea0a3981df',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Boulder',
+        'generation': 9,
+        'dexNo': '1022'
+      }
+    }
   },
   '0fb5b891-5a8c-40de-a064-8b178fb7bc08': {
-    data: {
-      id: '0fb5b891-5a8c-40de-a064-8b178fb7bc08',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Iron Crown',
-        generation: 9,
-        dexNo: '1023',
-      },
-    },
+    'data': {
+      'id': '0fb5b891-5a8c-40de-a064-8b178fb7bc08',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Iron Crown',
+        'generation': 9,
+        'dexNo': '1023'
+      }
+    }
   },
   '847aef18-fc51-4894-927e-f8348dc8773f': {
-    data: {
-      id: '847aef18-fc51-4894-927e-f8348dc8773f',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Terapagos',
-        generation: 9,
-        dexNo: '1024',
-      },
-    },
+    'data': {
+      'id': '847aef18-fc51-4894-927e-f8348dc8773f',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Terapagos',
+        'generation': 9,
+        'dexNo': '1024'
+      }
+    }
   },
   'eb1a9bbf-db5d-444c-8ece-4e9749120d52': {
-    data: {
-      id: 'eb1a9bbf-db5d-444c-8ece-4e9749120d52',
-      type: 'pokemon' as 'pokemon',
-      attributes: {
-        name: 'Pecharunt',
-        generation: 9,
-        dexNo: '1025',
-      },
-    },
-  },
+    'data': {
+      'id': 'eb1a9bbf-db5d-444c-8ece-4e9749120d52',
+      'type': 'pokemon' as 'pokemon',
+      'attributes': {
+        'name': 'Pecharunt',
+        'generation': 9,
+        'dexNo': '1025'
+      }
+    }
+  }
 };


### PR DESCRIPTION
This PR applies consistent formatting to the Generation 9 pokemon data file by:

- Adding quotes around all object keys (e.g., `data` → `'data'`, `id` → `'id'`)
- Removing trailing commas from the last property in objects
- Adjusting spacing around type annotations (e.g., `pokemonDataGen9: IPokemonEntities` → `pokemonDataGen9:IPokemonEntities`)

These changes standardize the code style across the entire `gen9.data.ts` file to match project conventions.

https://claude.ai/code/session_01MW253mZxnV4s19MbcfShsG