### PR TITLE
Add Bottom Rung 2 point for Sean G (Avalugg)

### DIFF
--- a/src/data/points/2026/16.data.ts
+++ b/src/data/points/2026/16.data.ts
@@ -1,3 +1,42 @@
 import { IPointEntities } from 'store/reducers';
 
-export const pointsData2026_16: IPointEntities = {};
+export const pointsData2026_16: IPointEntities = {
+  //  Bottom Rung 2 Aug 2026 to 15 Aug 2026
+  //  Sean G (@lostlemon)
+  //  0713. Avalugg
+  'f2109d73-493a-47f5-b58c-73e796c1d539': {
+    data: {
+      id: 'f2109d73-493a-47f5-b58c-73e796c1d539',
+      type: 'point',
+      attributes: {
+        ball: null,
+        catchDate: '2026-08-03',
+        firstCatch: true,
+        game: null,
+        method: null,
+        oldSystemPoint: false,
+        value: 1,
+      },
+      relationships: {
+        competition: {
+          data: {
+            id: 'edfc5e06-b7b4-4193-b46b-86283dd22d9e',
+            type: 'competition',
+          },
+        },
+        player: {
+          data: {
+            id: '0e59368f-37ea-44c9-bc7a-8ce047a1447f',
+            type: 'player',
+          },
+        },
+        pokemon: {
+          data: {
+            id: '06e87530-bdd5-41cd-8a70-197d8f70035a',
+            type: 'pokemon',
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Adds the first point entry for the Bottom Rung 2 competition (2 Aug 2026 to 15 Aug 2026).

## Changes
- Added point entry for Sean G (@lostlemon) catching Avalugg on 2026-08-03
- Marked as `firstCatch: true` (first point in this competition)
- Dex #0713 (Avalugg)

https://claude.ai/code/session_01EGke7gdm9wJLhQN4a4q1vV